### PR TITLE
Break down resource usage and request throughput in pod Live View by container name.

### DIFF
--- a/pxl_scripts/px/pod/pod.pxl
+++ b/pxl_scripts/px/pod/pod.pxl
@@ -66,6 +66,7 @@ def resource_timeseries(start_time: str, pod: px.Pod):
     df = px.DataFrame(table='process_stats', start_time=start_time)
     df = df[df.ctx['pod'] == pod]
     df.timestamp = px.bin(df.time_, px.seconds(window_s))
+    df.container = df.ctx['container_name']
 
     # Convert bytes to MB.
     df.vsize_mb = df.vsize_bytes / bytes_per_mb
@@ -81,7 +82,7 @@ def resource_timeseries(start_time: str, pod: px.Pod):
 
     # First calculate CPU usage by process (UPID) in each k8s_object
     # over all windows.
-    df = df.groupby(['upid', 'timestamp']).agg(
+    df = df.groupby(['upid', 'container', 'timestamp']).agg(
         rss_mb=('rss_mb', px.mean),
         vsize_mb=('vsize_mb', px.mean),
         # The fields below are counters, so we take the min and the max to subtract them.
@@ -108,7 +109,7 @@ def resource_timeseries(start_time: str, pod: px.Pod):
     df.wchar_mb = df.wchar_mb_max - df.wchar_mb_min
 
     # Then aggregate process individual process metrics.
-    df = df.groupby(['timestamp']).agg(
+    df = df.groupby(['container', 'timestamp']).agg(
         cpu_ktime_ms=('cpu_ktime_ms', px.sum),
         cpu_utime_ms=('cpu_utime_ms', px.sum),
         read_mb=('read_mb', px.sum),
@@ -181,8 +182,8 @@ def network_timeseries(start_time: str, pod: px.Pod):
     return df
 
 
-def inbound_let_timeseries(start_time: str, pod: px.Pod):
-    ''' Compute the let as a timeseries for requests received by `pod`.
+def inbound_latency_timeseries(start_time: str, pod: px.Pod):
+    ''' Compute the latency as a timeseries for requests received by `pod`.
 
     Args:
     @start_time: The timestamp of data to start at.
@@ -193,26 +194,45 @@ def inbound_let_timeseries(start_time: str, pod: px.Pod):
     df = df[df.pod == pod]
 
     df = df.groupby(['timestamp']).agg(
-        latency_quantiles=('latency_ms', px.quantiles),
+        latency_quantiles=('latency_ms', px.quantiles)
+    )
+
+    # Format the result of LET aggregates into proper scalar formats and
+    # time series.
+    df.latency_p50 = px.pluck_float64(df.latency_quantiles, 'p50')
+    df.latency_p90 = px.pluck_float64(df.latency_quantiles, 'p90')
+    df.latency_p99 = px.pluck_float64(df.latency_quantiles, 'p99')
+    df.time_ = df.timestamp
+    return df[['time_', 'latency_p50', 'latency_p90', 'latency_p99']]
+
+
+def inbound_request_timeseries_by_container(start_time: str, pod: px.Pod):
+    ''' Compute the request statistics as a timeseries for requests received
+        by `pod` by container.
+
+    Args:
+    @start_time: The timestamp of data to start at.
+    @pod: The name of the pod to filter on.
+
+    '''
+    df = let_helper(start_time)
+    df = df[df.pod == pod]
+    df.container = df.ctx['container']
+
+    df = df.groupby(['timestamp', 'container']).agg(
         error_rate_per_window=('failure', px.mean),
-        throughput_total=('latency_ms', px.count),
-        bytes_total=('resp_size', px.sum)
+        throughput_total=('latency_ms', px.count)
     )
 
     # Format the result of LET aggregates into proper scalar formats and
     # time series.
     window_size = window_s * 1.0
-    df.latency_p50 = px.pluck_float64(df.latency_quantiles, 'p50')
-    df.latency_p90 = px.pluck_float64(df.latency_quantiles, 'p90')
-    df.latency_p99 = px.pluck_float64(df.latency_quantiles, 'p99')
     df.requests_per_s = df.throughput_total / window_size
     df.errors_per_s = df.error_rate_per_window * df.requests_per_s
     df.error_rate_pct = df.error_rate_per_window * 100
-    df.bytes_per_s = df.bytes_total / window_size
     df.time_ = df.timestamp
 
-    return df[['time_', 'latency_p50', 'latency_p90', 'latency_p99',
-               'requests_per_s', 'errors_per_s', 'error_rate_pct', 'bytes_per_s']]
+    return df[['time_', 'container', 'requests_per_s', 'errors_per_s', 'error_rate_pct']]
 
 
 def inbound_let_summary(start_time: str, pod: px.Pod):

--- a/pxl_scripts/px/pod/vis.json
+++ b/pxl_scripts/px/pod/vis.json
@@ -15,9 +15,25 @@
   ],
   "globalFuncs": [
     {
-      "outputName": "inbound_let_timeseries",
+      "outputName": "inbound_latency",
       "func": {
-        "name": "inbound_let_timeseries",
+        "name": "inbound_latency_timeseries",
+        "args": [
+          {
+            "name": "start_time",
+            "variable": "start_time"
+          },
+          {
+            "name": "pod",
+            "variable": "pod"
+          }
+        ]
+      }
+    },
+    {
+      "outputName": "inbound_requests",
+      "func": {
+        "name": "inbound_request_timeseries_by_container",
         "args": [
           {
             "name": "start_time",
@@ -66,13 +82,15 @@
   "widgets": [
     {
       "name": "HTTP Requests",
-      "globalFuncOutputName": "inbound_let_timeseries",
+      "globalFuncOutputName": "inbound_requests",
       "displaySpec": {
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
             "value": "requests_per_s",
-            "mode": "MODE_LINE"
+            "mode": "MODE_AREA",
+            "series": "container",
+            "stackBySeries": true
           }
         ],
         "title": "",
@@ -90,13 +108,15 @@
     },
     {
       "name": "HTTP Errors",
-      "globalFuncOutputName": "inbound_let_timeseries",
+      "globalFuncOutputName": "inbound_requests",
       "displaySpec": {
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
             "value": "errors_per_s",
-            "mode": "MODE_LINE"
+            "mode": "MODE_AREA",
+            "series": "container",
+            "stackBySeries": true
           }
         ],
         "title": "",
@@ -114,7 +134,7 @@
     },
     {
       "name": "HTTP Latency",
-      "globalFuncOutputName": "inbound_let_timeseries",
+      "globalFuncOutputName": "inbound_latency",
       "displaySpec": {
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
@@ -152,7 +172,9 @@
         "timeseries": [
           {
             "value": "cpu_pct",
-            "mode": "MODE_LINE"
+            "mode": "MODE_AREA",
+            "series": "container",
+            "stackBySeries": true
           }
         ],
         "title": "",
@@ -163,34 +185,6 @@
       },
       "position": {
         "x": 0,
-        "y": 3,
-        "w": 4,
-        "h": 3
-      }
-    },
-    {
-      "name": "Memory Usage",
-      "globalFuncOutputName": "resource_timeseries",
-      "displaySpec": {
-        "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
-        "timeseries": [
-          {
-            "value": "rss_mb",
-            "mode": "MODE_LINE"
-          },
-          {
-            "value": "vsize_mb",
-            "mode": "MODE_LINE"
-          }
-        ],
-        "title": "",
-        "yAxis": {
-          "label": "MB"
-        },
-        "xAxis": null
-      },
-      "position": {
-        "x": 4,
         "y": 3,
         "w": 4,
         "h": 3
@@ -215,7 +209,7 @@
         "@type": "pixielabs.ai/pl.vispb.Table"
       },
       "position": {
-        "x": 8,
+        "x": 4,
         "y": 3,
         "w": 4,
         "h": 3
@@ -241,35 +235,7 @@
       },
       "position": {
         "x": 8,
-        "y": 6,
-        "w": 4,
-        "h": 3
-      }
-    },
-    {
-      "name": "Bytes Read and Written",
-      "globalFuncOutputName": "resource_timeseries",
-      "displaySpec": {
-        "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
-        "timeseries": [
-          {
-            "value": "rchar_mb",
-            "mode": "MODE_LINE"
-          },
-          {
-            "value": "wchar_mb",
-            "mode": "MODE_LINE"
-          }
-        ],
-        "title": "",
-        "yAxis": {
-          "label": "MB per s"
-        },
-        "xAxis": null
-      },
-      "position": {
-        "x": 0,
-        "y": 6,
+        "y": 3,
         "w": 4,
         "h": 3
       }
@@ -296,8 +262,112 @@
         "xAxis": null
       },
       "position": {
+        "x": 0,
+        "y": 6,
+        "w": 4,
+        "h": 3
+      }
+    },
+    {
+      "name": "Bytes Read",
+      "globalFuncOutputName": "resource_timeseries",
+      "displaySpec": {
+        "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
+        "timeseries": [
+          {
+            "value": "rchar_mb",
+            "mode": "MODE_AREA",
+            "series": "container",
+            "stackBySeries": true
+          }
+        ],
+        "title": "",
+        "yAxis": {
+          "label": "MB per s"
+        },
+        "xAxis": null
+      },
+      "position": {
         "x": 4,
         "y": 6,
+        "w": 4,
+        "h": 3
+      }
+    },
+    {
+      "name": "Bytes Written",
+      "globalFuncOutputName": "resource_timeseries",
+      "displaySpec": {
+        "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
+        "timeseries": [
+          {
+            "value": "wchar_mb",
+            "mode": "MODE_AREA",
+            "series": "container",
+            "stackBySeries": true
+          }
+        ],
+        "title": "",
+        "yAxis": {
+          "label": "MB per s"
+        },
+        "xAxis": null
+      },
+      "position": {
+        "x": 8,
+        "y": 6,
+        "w": 4,
+        "h": 3
+      }
+    },
+    {
+      "name": "Resident Set Size",
+      "globalFuncOutputName": "resource_timeseries",
+      "displaySpec": {
+        "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
+        "timeseries": [
+          {
+            "value": "rss_mb",
+            "mode": "MODE_AREA",
+            "series": "container",
+            "stackBySeries": true
+          }
+        ],
+        "title": "",
+        "yAxis": {
+          "label": "MB"
+        },
+        "xAxis": null
+      },
+      "position": {
+        "x": 0,
+        "y": 9,
+        "w": 4,
+        "h": 3
+      }
+    },
+    {
+      "name": "Virtual Memory Size",
+      "globalFuncOutputName": "resource_timeseries",
+      "displaySpec": {
+        "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
+        "timeseries": [
+          {
+            "value": "vsize_mb",
+            "mode": "MODE_AREA",
+            "series": "container",
+            "stackBySeries": true
+          }
+        ],
+        "title": "",
+        "yAxis": {
+          "label": "MB"
+        },
+        "xAxis": null
+      },
+      "position": {
+        "x": 4,
+        "y": 9,
         "w": 4,
         "h": 3
       }
@@ -322,7 +392,7 @@
       },
       "position": {
         "x": 0,
-        "y": 9,
+        "y": 12,
         "w": 12,
         "h": 3
       }
@@ -347,7 +417,7 @@
       },
       "position": {
         "x": 0,
-        "y": 12,
+        "y": 15,
         "w": 12,
         "h": 3
       }


### PR DESCRIPTION
We want to be able to show the proportional contribution of each container on a pod's resource usage and request throughput.  This change adds that support to do so in the pod Live View. 