### PR TITLE
Add connections by IP

### DIFF
--- a/pxl_scripts/px/connections_by_ip/connections_by_ip.pxl
+++ b/pxl_scripts/px/connections_by_ip/connections_by_ip.pxl
@@ -1,0 +1,31 @@
+# Copyright (c) Pixie Labs, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License")
+
+''' Connections to a list of remote IPs
+Finds services that have traffic to a list of IP addresses
+Calculates total bandwidth for the lifetime of the connection.
+'''
+import px
+
+
+def talk_to_ips():
+    df = px.DataFrame('conn_stats')
+    # Change the IP addresses for your remote endpoints.
+    df = df[px.equals_any(df.remote_addr, ['10.16.0.1'])]
+    # Insert the pod name.
+    df.pod = df.ctx['pod']
+
+    # Uncomment to show namespace in place of pod.
+    # df.pod = px.pod_name_to_namespace(df.pod)
+
+    # Insert the cmdline.
+    df.cmdline = df.ctx['cmd']
+    # Aggregate the connections.
+    df = df.groupby(['pod', 'upid', 'cmdline', 'remote_addr']).agg(
+        bytes_sent=('bytes_sent', px.max),
+        bytes_recv=('bytes_recv', px.max),
+    )
+    df = df[df.pod != '']
+    # Look up the names of the remote address.
+    df.ns = px.nslookup(df.remote_addr)
+    return df.drop(['remote_addr'])

--- a/pxl_scripts/px/connections_by_ip/manifest.yaml
+++ b/pxl_scripts/px/connections_by_ip/manifest.yaml
@@ -1,0 +1,5 @@
+---
+short: Connections by IP
+long: >
+  The set of k8s pods that talk to the specified IPs. Shows a graph and a table of the connections.
+  Calculates total bandwidth for the lifetime of the connection.

--- a/pxl_scripts/px/connections_by_ip/vis.json
+++ b/pxl_scripts/px/connections_by_ip/vis.json
@@ -1,0 +1,48 @@
+{
+  "variables": [],
+  "globalFuncs": [],
+  "widgets": [
+    {
+      "name": "Namespace Service Graph",
+      "position": {
+        "x": 0,
+        "y": 0,
+        "w": 6,
+        "h": 4
+      },
+      "func": {
+        "name": "talk_to_ips",
+        "args": []
+      },
+      "displaySpec": {
+        "@type": "pixielabs.ai/pl.vispb.Graph",
+        "adjacencyList": {
+          "fromColumn": "pod",
+          "toColumn": "ns"
+        },
+        "annotations": [
+          {
+            "name": "bytes_sent",
+            "value": "bytes_sent"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Table",
+      "position": {
+        "x": 6,
+        "y": 0,
+        "w": 6,
+        "h": 4
+      },
+      "func": {
+        "name": "talk_to_ips",
+        "args": []
+      },
+      "displaySpec": {
+        "@type": "pixielabs.ai/pl.vispb.Table"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5456019/92977020-b5004700-f440-11ea-9bf2-e0e0b79f3a53.png)
Connections by IP helps you find the Kubernetes pods that talk to external IPs and displays them as a graph.

Helpful for finding database clients, users of an external API, etc.