### PR TITLE
Net flow IPs as a list

### DIFF
--- a/pxl_scripts/px/net_flow_graph/net_flow_graph.pxl
+++ b/pxl_scripts/px/net_flow_graph/net_flow_graph.pxl
@@ -8,9 +8,9 @@ Calculates total bandwidth for the lifetime of the connection.
 import px
 
 
-def net_flow_graph(start: str, ips: str, grouping_entity: str):
+def net_flow_graph(start: str, ips: list, grouping_entity: str):
     df = px.DataFrame('conn_stats', start_time=start)
-    df = df[px.equals_any(df.remote_addr, [ips])]
+    df = df[px.equals_any(df.remote_addr, ips)]
 
     # Add the grouping entity column.
     df['from_entity'] = df.ctx[grouping_entity]

--- a/pxl_scripts/px/net_flow_graph/vis.json
+++ b/pxl_scripts/px/net_flow_graph/vis.json
@@ -2,9 +2,9 @@
   "variables": [
     {
       "name": "ips",
-      "type": "PX_LIST",
-      "description": "The IP address you wish to get the network flow into.",
-      "defaultValue": "['10.16.0.1']"
+      "type": "PX_STRING_LIST",
+      "description": "The IP addresses you wish to get the network flow into.",
+      "defaultValue": "10.16.0.1"
     },
     {
       "name": "start",

--- a/pxl_scripts/px/net_flow_graph/vis.json
+++ b/pxl_scripts/px/net_flow_graph/vis.json
@@ -2,9 +2,9 @@
   "variables": [
     {
       "name": "ips",
-      "type": "PX_STRING",
+      "type": "PX_LIST",
       "description": "The IP address you wish to get the network flow into.",
-      "defaultValue": "10.16.0.1"
+      "defaultValue": "['10.16.0.1']"
     },
     {
       "name": "start",


### PR DESCRIPTION
After the list support in the compiler lands, we can pass IPs as a list. 