### PR TITLE
TCP retransmission graph: Increase edge length

### DIFF
--- a/pxl_scripts/px/tcp_retransmits/vis.json
+++ b/pxl_scripts/px/tcp_retransmits/vis.json
@@ -27,6 +27,7 @@
         },
         "edgeWeightColumn": "retransmits",
         "edgeColorColumn": "retransmits",
+        "edgeLength": 300,
         "edgeThresholds": {
           "mediumThreshold": 5,
           "highThreshold": 50


### PR DESCRIPTION
To avoid overcrowding in the visualization.