### PR TITLE
Remove color from edges of netflow graph

### DIFF
--- a/pxl_scripts/px/net_flow_graph/vis.json
+++ b/pxl_scripts/px/net_flow_graph/vis.json
@@ -58,11 +58,6 @@
           "toColumn": "to_entity"
         },
         "edgeWeightColumn": "bytes_total",
-        "edgeColorColumn": "bytes_total",
-        "edgeThresholds": {
-          "mediumThreshold": 50000,
-          "highThreshold": 500000
-        },
         "edgeHoverInfo": [
           "bytes_total",
           "bytes_sent",


### PR DESCRIPTION
We should not color based on the number of bytes. More bytes != errors. 