### PR TITLE
Increase max-line-length in .pxl.flake8rc rules

### DIFF
--- a/.pxl.flake8rc
+++ b/.pxl.flake8rc
@@ -1,5 +1,5 @@
 [flake8]
-max-line-length = 100
+max-line-length = 120
 
 # N802: Function names have to be lower case. This is for GRPC service.
 # E999: Mistaken error see https://github.com/PyCQA/pycodestyle/issues/584


### PR DESCRIPTION
Distributed bpftrace deployment requires that the `printf` statement be on one line. The current max-line-length limits us from landing https://github.com/pixie-labs/pixie/pull/135. Our internal dev repo uses 120. 