### PR TITLE
Add valid values to px/node and px/net_flow_graph

### DIFF
--- a/pxl_scripts/px/net_flow_graph/vis.json
+++ b/pxl_scripts/px/net_flow_graph/vis.json
@@ -16,7 +16,13 @@
       "name": "grouping_entity",
       "type": "PX_STRING",
       "description": "The k8s object to group connections by.",
-      "defaultValue": "pod"
+      "defaultValue": "pod",
+      "validValues": [
+        "node",
+        "service",
+        "pod",
+        "namespace"
+      ]
     }
   ],
   "globalFuncs": [

--- a/pxl_scripts/px/node/vis.json
+++ b/pxl_scripts/px/node/vis.json
@@ -16,7 +16,13 @@
       "name": "groupby",
       "type": "PX_STRING",
       "description": "The element to groupby",
-      "defaultValue": "node"
+      "defaultValue": "node",
+      "validValues": [
+        "node",
+        "service",
+        "pod",
+        "namespace"
+      ]
     }
   ],
   "globalFuncs": [


### PR DESCRIPTION
New UI changes allow users to restrict the set of valid values for vis spec variables. This updates the two scripts that need this restriction to reduce user error.