### PR TITLE
 Make scripts output correct semantic types.

### DIFF
--- a/pxl_scripts/px/cluster/cluster.pxl
+++ b/pxl_scripts/px/cluster/cluster.pxl
@@ -1,18 +1,17 @@
 # Copyright (c) Pixie Labs, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License")
-
 ''' Cluster Overview
 
 This view lists the namespaces and the nodes that are available on the current cluster.
 
 '''
-
 import px
 
 
-bytes_per_mb = 1024.0 * 1024.0
+ns_per_ms = 1000 * 1000
+ns_per_s = 1000 * ns_per_ms
 # Window size to use on time_ column for bucketing.
-window_s = 10
+window_ns = px.DurationNanos(10 * ns_per_s)
 # Flag to filter out requests that come from an unresolvable IP.
 filter_unresolved_inbound = True
 # Flag to filter out health checks from the data.
@@ -23,7 +22,6 @@ filter_ready_checks = True
 
 def nodes_for_cluster(start_time: str):
     ''' Gets a list of nodes in the current cluster since `start_time`.
-
     Args:
     @start: Start time of the data to examine.
     '''
@@ -40,99 +38,80 @@ def nodes_for_cluster(start_time: str):
 
 def process_stats_by_entity(start_time: str, entity: str):
     ''' Gets the windowed process stats (CPU, memory, etc) per node or pod.
-
     Args:
     @start: Starting time of the data to examine.
     @entity: Either pod or node_name.
     '''
     df = px.DataFrame(table='process_stats', start_time=start_time)
     df[entity] = df.ctx[entity]
-    df.timestamp = px.bin(df.time_, px.seconds(window_s))
-
-    # Convert bytes to MB.
-    df.vsize_mb = df.vsize_bytes / bytes_per_mb
-    df.rss_mb = df.rss_bytes / bytes_per_mb
-    df.read_mb = df.read_bytes / bytes_per_mb
-    df.write_mb = df.write_bytes / bytes_per_mb
-    df.rchar_mb = df.rchar_bytes / bytes_per_mb
-    df.wchar_mb = df.wchar_bytes / bytes_per_mb
-
+    df.timestamp = px.bin(df.time_, window_ns)
     # Convert nanoseconds to milliseconds.
     df.cpu_utime_ms = df.cpu_utime_ns / 1.0E6
     df.cpu_ktime_ms = df.cpu_ktime_ns / 1.0E6
-
     # First calculate CPU usage by process (UPID) in each k8s_object
     # over all windows.
     df = df.groupby([entity, 'upid', 'timestamp']).agg(
-        rss_mb=('rss_mb', px.mean),
-        vsize_mb=('vsize_mb', px.mean),
+        rss_bytes=('rss_bytes', px.mean),
+        vsize_bytes=('vsize_bytes', px.mean),
         # The fields below are counters, so we take the min and the max to subtract them.
         cpu_utime_ms_max=('cpu_utime_ms', px.max),
         cpu_utime_ms_min=('cpu_utime_ms', px.min),
         cpu_ktime_ms_max=('cpu_ktime_ms', px.max),
         cpu_ktime_ms_min=('cpu_ktime_ms', px.min),
-        read_mb_max=('read_mb', px.max),
-        read_mb_min=('read_mb', px.min),
-        write_mb_max=('write_mb', px.max),
-        write_mb_min=('write_mb', px.min),
-        rchar_mb_max=('rchar_mb', px.max),
-        rchar_mb_min=('rchar_mb', px.min),
-        wchar_mb_max=('wchar_mb', px.max),
-        wchar_mb_min=('wchar_mb', px.min),
+        read_bytes_max=('read_bytes', px.max),
+        read_bytes_min=('read_bytes', px.min),
+        write_bytes_max=('write_bytes', px.max),
+        write_bytes_min=('write_bytes', px.min),
+        rchar_bytes_max=('rchar_bytes', px.max),
+        rchar_bytes_min=('rchar_bytes', px.min),
+        wchar_bytes_max=('wchar_bytes', px.max),
+        wchar_bytes_min=('wchar_bytes', px.min),
     )
-
     # Next calculate cpu usage and memory stats per window.
     df.cpu_utime_ms = df.cpu_utime_ms_max - df.cpu_utime_ms_min
     df.cpu_ktime_ms = df.cpu_ktime_ms_max - df.cpu_ktime_ms_min
-    df.read_mb = df.read_mb_max - df.read_mb_min
-    df.write_mb = df.write_mb_max - df.write_mb_min
-    df.rchar_mb = df.rchar_mb_max - df.rchar_mb_min
-    df.wchar_mb = df.wchar_mb_max - df.wchar_mb_min
-
+    df.read_bytes = df.read_bytes_max - df.read_bytes_min
+    df.write_bytes = df.write_bytes_max - df.write_bytes_min
+    df.rchar_bytes = df.rchar_bytes_max - df.rchar_bytes_min
+    df.wchar_bytes = df.wchar_bytes_max - df.wchar_bytes_min
     # Sum by UPID.
     df = df.groupby([entity, 'timestamp']).agg(
         cpu_ktime_ms=('cpu_ktime_ms', px.sum),
         cpu_utime_ms=('cpu_utime_ms', px.sum),
-        read_mb=('read_mb', px.sum),
-        write_mb=('write_mb', px.sum),
-        rchar_mb=('rchar_mb', px.sum),
-        wchar_mb=('wchar_mb', px.sum),
-        rss_mb=('rss_mb', px.sum),
-        vsize_mb=('vsize_mb', px.sum),
+        read_bytes=('read_bytes', px.sum),
+        write_bytes=('write_bytes', px.sum),
+        rchar_bytes=('rchar_bytes', px.sum),
+        wchar_bytes=('wchar_bytes', px.sum),
+        rss_bytes=('rss_bytes', px.sum),
+        vsize_bytes=('vsize_bytes', px.sum),
     )
-
-    window_size = window_s * 1.0
-    df.read_mb_per_s = df.read_mb / window_size
-    df.write_mb_per_s = df.write_mb / window_size
-    df.rchar_mb_per_s = df.rchar_mb / window_size
-    df.wchar_mb_per_s = df.wchar_mb / window_size
-
+    df.read_bytes_per_ns = df.read_bytes / window_ns
+    df.write_bytes_per_ns = df.write_bytes / window_ns
+    df.rchar_bytes_per_ns = df.rchar_bytes / window_ns
+    df.wchar_bytes_per_ns = df.wchar_bytes / window_ns
     # Now take the mean value over the various timestamps.
     df = df.groupby(entity).agg(
         cpu_ktime_ms=('cpu_ktime_ms', px.mean),
         cpu_utime_ms=('cpu_utime_ms', px.mean),
-        read_mb_per_s=('read_mb_per_s', px.mean),
-        write_mb_per_s=('write_mb_per_s', px.mean),
-        rchar_mb_per_s=('rchar_mb_per_s', px.mean),
-        wchar_mb_per_s=('wchar_mb_per_s', px.mean),
-        avg_rss_mb=('rss_mb', px.mean),
-        avg_vsize_mb=('vsize_mb', px.mean),
+        read_bytes_per_ns=('read_bytes_per_ns', px.mean),
+        write_bytes_per_ns=('write_bytes_per_ns', px.mean),
+        rchar_bytes_per_ns=('rchar_bytes_per_ns', px.mean),
+        wchar_bytes_per_ns=('wchar_bytes_per_ns', px.mean),
+        avg_rss_bytes=('rss_bytes', px.mean),
+        avg_vsize_bytes=('vsize_bytes', px.mean),
     )
-
-    # Convert window_s into the same units as cpu time.
-    window_size_ms = window_s * 1.0E3
+    # Convert window_ns into the same units as cpu time.
+    window_ms = window_ns * 1.0E3
     # Finally, calculate total (kernel + user time)  percentage used over window.
-    df.cpu_pct = (df.cpu_ktime_ms + df.cpu_utime_ms) / window_size_ms * 100
+    df.cpu_pct = px.Percent((df.cpu_ktime_ms + df.cpu_utime_ms) / window_ms)
     return df.drop(['cpu_ktime_ms', 'cpu_utime_ms'])
 
 
 def pods_for_cluster(start_time: str):
     ''' A list of pods in `namespace`.
-
     Args:
     @start_time: The timestamp of data to start at.
     @namespace: The name of the namespace to filter on.
-
     '''
     df = px.DataFrame(table='process_stats', start_time=start_time)
     df.pod = df.ctx['pod_name']
@@ -145,13 +124,12 @@ def pods_for_cluster(start_time: str):
     process_stats = process_stats_by_entity(start_time, 'pod')
     output = process_stats.merge(df, how='inner', left_on='pod', right_on='pod',
                                  suffixes=['', '_x'])
-    return output[['pod', 'cpu_pct', 'rchar_mb_per_s', 'wchar_mb_per_s', 'container_count',
+    return output[['pod', 'cpu_pct', 'rchar_bytes_per_ns', 'wchar_bytes_per_ns', 'container_count',
                    'node', 'start_time', 'status']]
 
 
 def namespaces_for_cluster(start_time: str):
     ''' Gets a overview of namespaces in the current cluster since `start_time`.
-
     Args:
     @start: Start time of the data to examine.
     '''
@@ -160,29 +138,23 @@ def namespaces_for_cluster(start_time: str):
     df.pod = df.ctx['pod_name']
     df.namespace = df.ctx['namespace']
     agg = df.groupby(['service', 'pod', 'namespace']).agg()
-
     pod_count = agg.groupby(['namespace', 'pod']).agg()
     pod_count = pod_count.groupby('namespace').agg(pod_count=('pod', px.count))
-
     svc_count = agg.groupby(['namespace', 'service']).agg()
     svc_count = svc_count.groupby('namespace').agg(service_count=('service', px.count))
-
     pod_and_svc_count = pod_count.merge(svc_count, how='inner',
                                         left_on='namespace', right_on='namespace',
                                         suffixes=['', '_x'])
-
     process_stats = process_stats_by_entity(start_time, 'namespace')
     output = process_stats.merge(pod_and_svc_count, how='inner', left_on='namespace',
                                  right_on='namespace', suffixes=['', '_y'])
-    return output[['namespace', 'pod_count', 'service_count', 'avg_vsize_mb', 'avg_rss_mb']]
+    return output[['namespace', 'pod_count', 'service_count', 'avg_vsize_bytes', 'avg_rss_bytes']]
 
 
 def services_for_cluster(start_time: str):
     ''' Get an overview of the services in the current cluster.
-
     Args:
     @start_time: The timestamp of data to start at.
-
     '''
     df = px.DataFrame(table='process_stats', start_time=start_time)
     df.service = df.ctx['service']
@@ -199,70 +171,57 @@ def services_for_cluster(start_time: str):
 def inbound_service_let_summary(start_time: str):
     ''' Compute a summary of traffic by requesting service, for requests
         on services in the current cluster..
-
     Args:
     @start_time: The timestamp of data to start at.
-
     '''
     df = inbound_service_let_helper(start_time)
     df = df[df.remote_addr != '']
     df.responder = df.service
-
     per_s_df = df.groupby(['timestamp', 'service']).agg(
-        throughput_total=('latency_ms', px.count),
+        throughput_total=('latency_ns', px.count),
         inbound_bytes_total=('req_size', px.sum),
         outbound_bytes_total=('resp_size', px.sum)
     )
-
-    window_size = 1.0 * window_s
-    per_s_df.requests_per_s = per_s_df.throughput_total / window_size
-    per_s_df.inbound_bytes_per_s = per_s_df.inbound_bytes_total / window_size
-    per_s_df.outbound_bytes_per_s = per_s_df.inbound_bytes_total / window_size
-
+    per_s_df.requests_per_ns = per_s_df.throughput_total / window_ns
+    per_s_df.inbound_bytes_per_ns = per_s_df.inbound_bytes_total / window_ns
+    per_s_df.outbound_bytes_per_ns = per_s_df.inbound_bytes_total / window_ns
     per_s_df = per_s_df.groupby('service').agg(
-        requests_per_s=('requests_per_s', px.mean),
-        inbound_bytes_per_s=('inbound_bytes_per_s', px.mean),
-        outbound_bytes_per_s=('outbound_bytes_per_s', px.mean)
+        requests_per_ns=('requests_per_ns', px.mean),
+        inbound_bytes_per_ns=('inbound_bytes_per_ns', px.mean),
+        outbound_bytes_per_ns=('outbound_bytes_per_ns', px.mean)
     )
-
     quantiles_df = df.groupby('service').agg(
-        latency_ms=('latency_ms', px.quantiles)
+        latency_ns=('latency_ns', px.quantiles)
         error_rate=('failure', px.mean),
     )
-
-    quantiles_df.error_rate_pct = quantiles_df.error_rate * 100 / window_size
-
+    quantiles_df.error_rate_pct = px.Percent(quantiles_df.error_rate)
     joined = per_s_df.merge(quantiles_df, left_on='service',
                             right_on='service', how='inner',
                             suffixes=['', '_x'])
-    return joined[['service', 'latency_ms', 'requests_per_s', 'error_rate_pct',
-                   'inbound_bytes_per_s', 'outbound_bytes_per_s']]
+    return joined[['service', 'latency_ns', 'requests_per_ns', 'error_rate_pct',
+                   'inbound_bytes_per_ns', 'outbound_bytes_per_ns']]
 
 
 def inbound_service_let_helper(start_time: str):
     ''' Compute the let as a timeseries for requests received or by services in `namespace`.
-
     Args:
     @start_time: The timestamp of data to start at.
     @namespace: The namespace to filter on.
     @groupby_cols: The columns to group on.
-
     '''
     df = px.DataFrame(table='http_events', start_time=start_time)
     df.service = df.ctx['service']
     df.pod = df.ctx['pod_name']
     df = df[df.service != '']
-    df.latency_ms = df.http_resp_latency_ns / 1.0E6
-    df = df[df['latency_ms'] < 10000.0]
-    df.timestamp = px.bin(df.time_, px.seconds(window_s))
-
-    df.req_size = px.length(df.http_req_body)
-    df.resp_size = px.length(df.http_resp_body)
+    df.latency_ns = df.http_resp_latency_ns
+    df = df[df['latency_ns'] < (10000 * ns_per_ms)]
+    df.timestamp = px.bin(df.time_, window_ns)
+    df.req_size = px.Bytes(px.length(df.http_req_body))
+    df.resp_size = px.Bytes(px.length(df.http_resp_body))
     df.failure = df.http_resp_status >= 400
     filter_out_conds = ((df.http_req_path != '/health' or not filter_health_checks) and (
         df.http_req_path != '/readyz' or not filter_ready_checks)) and (
         df['remote_addr'] != '-' or not filter_unresolved_inbound)
-
     df = df[filter_out_conds]
     return df
 
@@ -271,44 +230,38 @@ def inbound_let_service_graph(start_time: str):
     ''' Compute a summary of traffic by requesting service, for requests on services
         in the current cluster. Similar to `inbound_let_summary` but also breaks down
         by pod in addition to service.
-
     Args:
     @start_time: The timestamp of data to start at.
     '''
     df = inbound_service_let_helper(start_time)
     df = df.groupby(['timestamp', 'service', 'remote_addr', 'pod']).agg(
-        latency_quantiles=('latency_ms', px.quantiles),
+        latency_quantiles=('latency_ns', px.quantiles),
         error_rate=('failure', px.mean),
-        throughput_total=('latency_ms', px.count),
+        throughput_total=('latency_ns', px.count),
         inbound_bytes_total=('req_size', px.sum),
         outbound_bytes_total=('resp_size', px.sum)
     )
-
     df.latency_p50 = px.pluck_float64(df.latency_quantiles, 'p50')
     df.latency_p90 = px.pluck_float64(df.latency_quantiles, 'p90')
     df.latency_p99 = px.pluck_float64(df.latency_quantiles, 'p99')
-
     df = df[df.remote_addr != '']
     df.responder_pod = df.pod
     df.requestor_pod_id = px.ip_to_pod_id(df.remote_addr)
     df.requestor_pod = px.pod_id_to_pod_name(df.requestor_pod_id)
     df.responder_service = df.service
     df.requestor_service = px.pod_id_to_service_name(df.requestor_pod_id)
-
-    window_size = 1.0 * window_s
-    df.requests_per_s = df.throughput_total / window_size
-    df.inbound_bytes_per_s = df.inbound_bytes_total / window_size
-    df.outbound_bytes_per_s = df.outbound_bytes_total / window_size
-    df.error_rate_pct = df.error_rate * 100 / window_size
-
+    df.requests_per_ns = df.throughput_total / window_ns
+    df.inbound_bytes_per_ns = df.inbound_bytes_total / window_ns
+    df.outbound_bytes_per_ns = df.outbound_bytes_total / window_ns
+    df.error_rate_pct = px.Percent(df.error_rate)
     return df.groupby(['responder_pod', 'requestor_pod', 'responder_service',
                        'requestor_service']).agg(
         latency_p50=('latency_p50', px.mean),
         latency_p90=('latency_p90', px.mean),
         latency_p99=('latency_p99', px.mean),
-        requests_per_s=('requests_per_s', px.mean),
+        requests_per_ns=('requests_per_ns', px.mean),
         error_rate_pct=('error_rate_pct', px.mean),
-        inbound_bytes_per_s=('inbound_bytes_per_s', px.mean),
-        outbound_bytes_per_s=('outbound_bytes_per_s', px.mean),
+        inbound_bytes_per_ns=('inbound_bytes_per_ns', px.mean),
+        outbound_bytes_per_ns=('outbound_bytes_per_ns', px.mean),
         throughput_total=('throughput_total', px.sum)
     )

--- a/pxl_scripts/px/cluster/cluster.pxl
+++ b/pxl_scripts/px/cluster/cluster.pxl
@@ -33,7 +33,7 @@ def nodes_for_cluster(start_time: str):
     process_stats = process_stats_by_entity(start_time, 'node')
     output = process_stats.merge(nodes, how='inner', left_on='node', right_on='node',
                                  suffixes=['', '_x'])
-    return output[['node', 'cpu_pct', 'pod_count']]
+    return output[['node', 'cpu_usage', 'pod_count']]
 
 
 def process_stats_by_entity(start_time: str, entity: str):
@@ -45,19 +45,16 @@ def process_stats_by_entity(start_time: str, entity: str):
     df = px.DataFrame(table='process_stats', start_time=start_time)
     df[entity] = df.ctx[entity]
     df.timestamp = px.bin(df.time_, window_ns)
-    # Convert nanoseconds to milliseconds.
-    df.cpu_utime_ms = df.cpu_utime_ns / 1.0E6
-    df.cpu_ktime_ms = df.cpu_ktime_ns / 1.0E6
     # First calculate CPU usage by process (UPID) in each k8s_object
     # over all windows.
     df = df.groupby([entity, 'upid', 'timestamp']).agg(
-        rss_bytes=('rss_bytes', px.mean),
-        vsize_bytes=('vsize_bytes', px.mean),
+        rss=('rss_bytes', px.mean),
+        vsize=('vsize_bytes', px.mean),
         # The fields below are counters, so we take the min and the max to subtract them.
-        cpu_utime_ms_max=('cpu_utime_ms', px.max),
-        cpu_utime_ms_min=('cpu_utime_ms', px.min),
-        cpu_ktime_ms_max=('cpu_ktime_ms', px.max),
-        cpu_ktime_ms_min=('cpu_ktime_ms', px.min),
+        cpu_utime_ns_max=('cpu_utime_ns', px.max),
+        cpu_utime_ns_min=('cpu_utime_ns', px.min),
+        cpu_ktime_ns_max=('cpu_ktime_ns', px.max),
+        cpu_ktime_ns_min=('cpu_ktime_ns', px.min),
         read_bytes_max=('read_bytes', px.max),
         read_bytes_min=('read_bytes', px.min),
         write_bytes_max=('write_bytes', px.max),
@@ -68,43 +65,41 @@ def process_stats_by_entity(start_time: str, entity: str):
         wchar_bytes_min=('wchar_bytes', px.min),
     )
     # Next calculate cpu usage and memory stats per window.
-    df.cpu_utime_ms = df.cpu_utime_ms_max - df.cpu_utime_ms_min
-    df.cpu_ktime_ms = df.cpu_ktime_ms_max - df.cpu_ktime_ms_min
+    df.cpu_utime_ns = df.cpu_utime_ns_max - df.cpu_utime_ns_min
+    df.cpu_ktime_ns = df.cpu_ktime_ns_max - df.cpu_ktime_ns_min
     df.read_bytes = df.read_bytes_max - df.read_bytes_min
     df.write_bytes = df.write_bytes_max - df.write_bytes_min
     df.rchar_bytes = df.rchar_bytes_max - df.rchar_bytes_min
     df.wchar_bytes = df.wchar_bytes_max - df.wchar_bytes_min
     # Sum by UPID.
     df = df.groupby([entity, 'timestamp']).agg(
-        cpu_ktime_ms=('cpu_ktime_ms', px.sum),
-        cpu_utime_ms=('cpu_utime_ms', px.sum),
+        cpu_ktime_ns=('cpu_ktime_ns', px.sum),
+        cpu_utime_ns=('cpu_utime_ns', px.sum),
         read_bytes=('read_bytes', px.sum),
         write_bytes=('write_bytes', px.sum),
         rchar_bytes=('rchar_bytes', px.sum),
         wchar_bytes=('wchar_bytes', px.sum),
-        rss_bytes=('rss_bytes', px.sum),
-        vsize_bytes=('vsize_bytes', px.sum),
+        rss=('rss', px.sum),
+        vsize=('vsize', px.sum),
     )
-    df.read_bytes_per_ns = df.read_bytes / window_ns
-    df.write_bytes_per_ns = df.write_bytes / window_ns
-    df.rchar_bytes_per_ns = df.rchar_bytes / window_ns
-    df.wchar_bytes_per_ns = df.wchar_bytes / window_ns
+    df.actual_disk_read_throughput = df.read_bytes / window_ns
+    df.actual_disk_write_throughput = df.write_bytes / window_ns
+    df.total_disk_read_throughput = df.rchar_bytes / window_ns
+    df.total_disk_write_throughput = df.wchar_bytes / window_ns
     # Now take the mean value over the various timestamps.
     df = df.groupby(entity).agg(
-        cpu_ktime_ms=('cpu_ktime_ms', px.mean),
-        cpu_utime_ms=('cpu_utime_ms', px.mean),
-        read_bytes_per_ns=('read_bytes_per_ns', px.mean),
-        write_bytes_per_ns=('write_bytes_per_ns', px.mean),
-        rchar_bytes_per_ns=('rchar_bytes_per_ns', px.mean),
-        wchar_bytes_per_ns=('wchar_bytes_per_ns', px.mean),
-        avg_rss_bytes=('rss_bytes', px.mean),
-        avg_vsize_bytes=('vsize_bytes', px.mean),
+        cpu_ktime_ns=('cpu_ktime_ns', px.mean),
+        cpu_utime_ns=('cpu_utime_ns', px.mean),
+        actual_disk_read_throughput=('actual_disk_read_throughput', px.mean),
+        actual_disk_write_throughput=('actual_disk_write_throughput', px.mean),
+        total_disk_read_throughput=('total_disk_read_throughput', px.mean),
+        total_disk_write_throughput=('total_disk_write_throughput', px.mean),
+        avg_rss=('rss', px.mean),
+        avg_vsize=('vsize', px.mean),
     )
-    # Convert window_ns into the same units as cpu time.
-    window_ms = window_ns * 1.0E3
     # Finally, calculate total (kernel + user time)  percentage used over window.
-    df.cpu_pct = px.Percent((df.cpu_ktime_ms + df.cpu_utime_ms) / window_ms)
-    return df.drop(['cpu_ktime_ms', 'cpu_utime_ms'])
+    df.cpu_usage = px.Percent((df.cpu_ktime_ns + df.cpu_utime_ns) / window_ns)
+    return df.drop(['cpu_ktime_ns', 'cpu_utime_ns'])
 
 
 def pods_for_cluster(start_time: str):
@@ -124,7 +119,8 @@ def pods_for_cluster(start_time: str):
     process_stats = process_stats_by_entity(start_time, 'pod')
     output = process_stats.merge(df, how='inner', left_on='pod', right_on='pod',
                                  suffixes=['', '_x'])
-    return output[['pod', 'cpu_pct', 'rchar_bytes_per_ns', 'wchar_bytes_per_ns', 'container_count',
+    return output[['pod', 'cpu_usage', 'total_disk_read_throughput',
+                   'total_disk_write_throughput', 'container_count',
                    'node', 'start_time', 'status']]
 
 
@@ -148,7 +144,7 @@ def namespaces_for_cluster(start_time: str):
     process_stats = process_stats_by_entity(start_time, 'namespace')
     output = process_stats.merge(pod_and_svc_count, how='inner', left_on='namespace',
                                  right_on='namespace', suffixes=['', '_y'])
-    return output[['namespace', 'pod_count', 'service_count', 'avg_vsize_bytes', 'avg_rss_bytes']]
+    return output[['namespace', 'pod_count', 'service_count', 'avg_vsize', 'avg_rss']]
 
 
 def services_for_cluster(start_time: str):
@@ -177,29 +173,29 @@ def inbound_service_let_summary(start_time: str):
     df = inbound_service_let_helper(start_time)
     df = df[df.remote_addr != '']
     df.responder = df.service
-    per_s_df = df.groupby(['timestamp', 'service']).agg(
-        throughput_total=('latency_ns', px.count),
+    per_ns_df = df.groupby(['timestamp', 'service']).agg(
+        throughput_total=('latency', px.count),
         inbound_bytes_total=('req_size', px.sum),
         outbound_bytes_total=('resp_size', px.sum)
     )
-    per_s_df.requests_per_ns = per_s_df.throughput_total / window_ns
-    per_s_df.inbound_bytes_per_ns = per_s_df.inbound_bytes_total / window_ns
-    per_s_df.outbound_bytes_per_ns = per_s_df.inbound_bytes_total / window_ns
-    per_s_df = per_s_df.groupby('service').agg(
-        requests_per_ns=('requests_per_ns', px.mean),
-        inbound_bytes_per_ns=('inbound_bytes_per_ns', px.mean),
-        outbound_bytes_per_ns=('outbound_bytes_per_ns', px.mean)
+    per_ns_df.request_throughput = per_ns_df.throughput_total / window_ns
+    per_ns_df.inbound_throughput = per_ns_df.inbound_bytes_total / window_ns
+    per_ns_df.outbound_throughput = per_ns_df.inbound_bytes_total / window_ns
+    per_ns_df = per_ns_df.groupby('service').agg(
+        request_throughput=('request_throughput', px.mean),
+        inbound_throughput=('inbound_throughput', px.mean),
+        outbound_throughput=('outbound_throughput', px.mean)
     )
     quantiles_df = df.groupby('service').agg(
-        latency_ns=('latency_ns', px.quantiles)
+        latency=('latency', px.quantiles)
         error_rate=('failure', px.mean),
     )
-    quantiles_df.error_rate_pct = px.Percent(quantiles_df.error_rate)
-    joined = per_s_df.merge(quantiles_df, left_on='service',
-                            right_on='service', how='inner',
-                            suffixes=['', '_x'])
-    return joined[['service', 'latency_ns', 'requests_per_ns', 'error_rate_pct',
-                   'inbound_bytes_per_ns', 'outbound_bytes_per_ns']]
+    quantiles_df.error_rate = px.Percent(quantiles_df.error_rate)
+    joined = per_ns_df.merge(quantiles_df, left_on='service',
+                             right_on='service', how='inner',
+                             suffixes=['', '_x'])
+    return joined[['service', 'latency', 'request_throughput', 'error_rate',
+                   'inbound_throughput', 'outbound_throughput']]
 
 
 def inbound_service_let_helper(start_time: str):
@@ -213,8 +209,8 @@ def inbound_service_let_helper(start_time: str):
     df.service = df.ctx['service']
     df.pod = df.ctx['pod_name']
     df = df[df.service != '']
-    df.latency_ns = df.http_resp_latency_ns
-    df = df[df['latency_ns'] < (10000 * ns_per_ms)]
+    df.latency = df.http_resp_latency_ns
+    df = df[df['latency'] < (10000 * ns_per_ms)]
     df.timestamp = px.bin(df.time_, window_ns)
     df.req_size = px.Bytes(px.length(df.http_req_body))
     df.resp_size = px.Bytes(px.length(df.http_resp_body))
@@ -235,9 +231,9 @@ def inbound_let_service_graph(start_time: str):
     '''
     df = inbound_service_let_helper(start_time)
     df = df.groupby(['timestamp', 'service', 'remote_addr', 'pod']).agg(
-        latency_quantiles=('latency_ns', px.quantiles),
+        latency_quantiles=('latency', px.quantiles),
         error_rate=('failure', px.mean),
-        throughput_total=('latency_ns', px.count),
+        throughput_total=('latency', px.count),
         inbound_bytes_total=('req_size', px.sum),
         outbound_bytes_total=('resp_size', px.sum)
     )
@@ -250,18 +246,18 @@ def inbound_let_service_graph(start_time: str):
     df.requestor_pod = px.pod_id_to_pod_name(df.requestor_pod_id)
     df.responder_service = df.service
     df.requestor_service = px.pod_id_to_service_name(df.requestor_pod_id)
-    df.requests_per_ns = df.throughput_total / window_ns
-    df.inbound_bytes_per_ns = df.inbound_bytes_total / window_ns
-    df.outbound_bytes_per_ns = df.outbound_bytes_total / window_ns
-    df.error_rate_pct = px.Percent(df.error_rate)
+    df.request_throughput = df.throughput_total / window_ns
+    df.inbound_throughput = df.inbound_bytes_total / window_ns
+    df.outbound_throughput = df.outbound_bytes_total / window_ns
+    df.error_rate = px.Percent(df.error_rate)
     return df.groupby(['responder_pod', 'requestor_pod', 'responder_service',
                        'requestor_service']).agg(
         latency_p50=('latency_p50', px.mean),
         latency_p90=('latency_p90', px.mean),
         latency_p99=('latency_p99', px.mean),
-        requests_per_ns=('requests_per_ns', px.mean),
-        error_rate_pct=('error_rate_pct', px.mean),
-        inbound_bytes_per_ns=('inbound_bytes_per_ns', px.mean),
-        outbound_bytes_per_ns=('outbound_bytes_per_ns', px.mean),
+        request_throughput=('request_throughput', px.mean),
+        error_rate=('error_rate', px.mean),
+        inbound_throughput=('inbound_throughput', px.mean),
+        outbound_throughput=('outbound_throughput', px.mean),
         throughput_total=('throughput_total', px.sum)
     )

--- a/pxl_scripts/px/cluster/vis.json
+++ b/pxl_scripts/px/cluster/vis.json
@@ -34,10 +34,10 @@
         "p50Column": "latency_p50",
         "p90Column": "latency_p90",
         "p99Column": "latency_p99",
-        "errorRateColumn": "error_rate_pct",
-        "requestsPerSecondColumn": "requests_per_ns",
-        "inboundBytesPerSecondColumn": "inbound_bytes_per_ns",
-        "outboundBytesPerSecondColumn": "outbound_bytes_per_ns",
+        "errorRateColumn": "error_rate",
+        "requestsPerSecondColumn": "request_throughput",
+        "inboundBytesPerSecondColumn": "inbound_throughput",
+        "outboundBytesPerSecondColumn": "outbound_throughput",
         "totalRequestCountColumn": "throughput_total"
       }
     },

--- a/pxl_scripts/px/cluster/vis.json
+++ b/pxl_scripts/px/cluster/vis.json
@@ -35,9 +35,9 @@
         "p90Column": "latency_p90",
         "p99Column": "latency_p99",
         "errorRateColumn": "error_rate_pct",
-        "requestsPerSecondColumn": "requests_per_s",
-        "inboundBytesPerSecondColumn": "inbound_bytes_per_s",
-        "outboundBytesPerSecondColumn": "outbound_bytes_per_s",
+        "requestsPerSecondColumn": "requests_per_ns",
+        "inboundBytesPerSecondColumn": "inbound_bytes_per_ns",
+        "outboundBytesPerSecondColumn": "outbound_bytes_per_ns",
         "totalRequestCountColumn": "throughput_total"
       }
     },

--- a/pxl_scripts/px/cql_data/data.pxl
+++ b/pxl_scripts/px/cql_data/data.pxl
@@ -5,7 +5,6 @@ import px
 
 t1 = px.DataFrame(table='cql_events', start_time='-30s')
 
-t1.latency_ms = t1.latency_ns / 1.0E6
-t2 = t1.drop(columns=['latency_ns']).head(n=100)
+t2 = t1.head(n=100)
 
 px.display(t2)

--- a/pxl_scripts/px/cql_stats/cql_stats.pxl
+++ b/pxl_scripts/px/cql_stats/cql_stats.pxl
@@ -52,7 +52,7 @@ def pod_cql_let(start: str, pod: px.Pod):
     """
     df = cql_let_per_pod(start, pod)
     return df['time_', split_series_name, ip_col_name, 'latency_p50',
-              'latency_p90', 'latency_p99', 'error_rate', 'requests_per_ns']
+              'latency_p90', 'latency_p99', 'error_rate', 'request_throughput']
 
 
 def summary_cql_let(start: str, pod: px.Pod):
@@ -69,7 +69,8 @@ def summary_cql_let(start: str, pod: px.Pod):
     """
     df = cql_let_per_pod(start, pod)
     summary_df = summarize_LET(df, [k8s_object, ip_col_name])
-    return summary_df[[k8s_object, ip_col_name, "requests_per_ns", "error_rate", "latency", "total_requests"]]
+    return summary_df[[k8s_object, ip_col_name, "request_throughput",
+                       "error_rate", "latency", "total_requests"]]
 
 
 def latency_histogram(start: str, pod: px.Pod):
@@ -92,9 +93,9 @@ def latency_histogram(start: str, pod: px.Pod):
     # over the time window ('timestamp') after filtering for matching svcs.
     matching_df = df[px.contains(df[k8s_object], pod)]
 
-    matching_df.request_latency_ns = px.bin(matching_df.latency_ns,
-                                            latency_bin_size_ns)
-    return matching_df.groupby('request_latency_ns').agg(count=('time_', px.count))
+    matching_df.request_latency = px.bin(matching_df.latency,
+                                         latency_bin_size_ns)
+    return matching_df.groupby('request_latency').agg(count=('time_', px.count))
 
 
 # ----------------------------------------------------------------
@@ -132,7 +133,7 @@ def cql_let_per_pod(start: str, pod: px.Pod):
     return let_df
 
 
-def format_events_table(df, latency_ns_col):
+def format_events_table(df, latency_col):
     """ Format data and add semantic columns in event tables
 
     Unifies latency column to 'latency_ms', adds a binned
@@ -143,11 +144,12 @@ def format_events_table(df, latency_ns_col):
 
     Args:
     @df: the input events table
-    @latency_ns_col: the name of the latency column in @df.
+    @latency_col: the name of the latency column in @df.
 
     Returns: formatted events DataFrame
     """
-    df = df[df[latency_ns_col] < (10000 * ns_per_ms)]
+    df.latency = df[latency_col]
+    df = df[df.latency < (10000 * ns_per_ms)]
     df.timestamp = px.bin(df.time_, window_ns)
     df[k8s_object] = df.ctx[k8s_object]
     df = df[df[k8s_object] != '']
@@ -177,7 +179,7 @@ def format_LET_aggs(df):
 
     Converts the result of aggregates on windows into well-formatted metrics that
     can be visualized. Latency quantile values need to be extracted from the
-    quantiles struct, and then error_rate, requests_per_ns, and bytes_per_ns are calculated as
+    quantiles struct, and then error_rate, request_throughput, and bytes_per_ns are calculated as
     a function of window size.
 
 
@@ -186,7 +188,7 @@ def format_LET_aggs(df):
 
     Args:
     @df: the input events table grouped into windows with aggregated
-        columns 'throughput_total', 'error_rate_per_window', and 'requests_per_ns'
+        columns 'throughput_total', 'error_rate_per_window', and 'request_throughput'
 
     Returns: DataFrame with formatted LET metrics.
     """
@@ -195,9 +197,9 @@ def format_LET_aggs(df):
     df.latency_p90 = px.pluck_float64(df.latency_quantiles, 'p90')
     df.latency_p99 = px.pluck_float64(df.latency_quantiles, 'p99')
     df['time_'] = df['timestamp']
-    df.requests_per_ns = df.throughput_total / window_ns
+    df.request_throughput = df.throughput_total / window_ns
     df.bytes_per_ns = df.bytes_total / window_ns
-    df.error_rate = df.error_rate_per_window * df.requests_per_ns / px.DurationNanos(1)
+    df.error_rate = df.error_rate_per_window * df.request_throughput / px.DurationNanos(1)
 
     return df
 
@@ -217,14 +219,14 @@ def calc_cql_LET(df, groups):
     """
     # All requests for errors and throughput
     et = df.groupby(groups).agg(
-        throughput_total=('latency_ns', px.count),
+        throughput_total=('latency', px.count),
         error_rate_per_window=('failure', px.mean),
     )
 
     filt_df = df[df.resp_op != 0]
     # Calculate latency on all requests that return or return an err.
     lcy = filt_df.groupby(groups).agg(
-        latency_quantiles=('latency_ns', px.quantiles),
+        latency_quantiles=('latency', px.quantiles),
         bytes_total=('resp_size', px.sum)
     )
     # Left join because et's groups are a strict superset of lcy.
@@ -266,7 +268,7 @@ def summarize_LET(let_df, groups):
     Returns: The summary DF.
     """
     df = let_df.groupby(groups).agg(
-        requests_per_ns=('requests_per_ns', px.mean),
+        request_throughput=('request_throughput', px.mean),
         bytes_per_ns=('bytes_per_ns', px.mean),
         error_rate=('error_rate', px.mean),
         total_requests=('throughput_total', px.sum),

--- a/pxl_scripts/px/cql_stats/cql_stats.pxl
+++ b/pxl_scripts/px/cql_stats/cql_stats.pxl
@@ -15,8 +15,10 @@ import px
 # K8s object is the abstraction to group on.
 # Options are ['pod', 'service'].
 k8s_object = 'pod'
-# Window in seconds within which to aggregate metrics.
-window_s = 10
+ns_per_ms = 1000 * 1000
+ns_per_s = 1000 * ns_per_ms
+# Window size to use on time_ column for bucketing.
+window_ns = px.DurationNanos(10 * ns_per_s)
 # Column name used to split data into separate time series.
 # k8s_object column is renamed to this and is used in
 # visualization spec.
@@ -26,7 +28,7 @@ ip_col_name = 'CQL IP'
 # Temporary way to ensure px.Pod works as expected.
 px.Pod = str
 # The bin size to use for the latency histogram.
-latency_bin_size_ms = 50
+latency_bin_size_ns = px.DurationNanos(50 * ns_per_ms)
 # ----------------------------------------------------------------
 
 
@@ -50,7 +52,7 @@ def pod_cql_let(start: str, pod: px.Pod):
     """
     df = cql_let_per_pod(start, pod)
     return df['time_', split_series_name, ip_col_name, 'latency_p50',
-              'latency_p90', 'latency_p99', 'error_rate', 'rps']
+              'latency_p90', 'latency_p99', 'error_rate', 'requests_per_ns']
 
 
 def summary_cql_let(start: str, pod: px.Pod):
@@ -67,7 +69,7 @@ def summary_cql_let(start: str, pod: px.Pod):
     """
     df = cql_let_per_pod(start, pod)
     summary_df = summarize_LET(df, [k8s_object, ip_col_name])
-    return summary_df[[k8s_object, ip_col_name, "rps", "error_rate", "latency", "total_requests"]]
+    return summary_df[[k8s_object, ip_col_name, "requests_per_ns", "error_rate", "latency", "total_requests"]]
 
 
 def latency_histogram(start: str, pod: px.Pod):
@@ -90,9 +92,9 @@ def latency_histogram(start: str, pod: px.Pod):
     # over the time window ('timestamp') after filtering for matching svcs.
     matching_df = df[px.contains(df[k8s_object], pod)]
 
-    matching_df.request_latency_ms = px.bin(matching_df.latency_ns / 1000 / 1000,
-                                            latency_bin_size_ms)
-    return matching_df.groupby('request_latency_ms').agg(count=('time_', px.count))
+    matching_df.request_latency_ns = px.bin(matching_df.latency_ns,
+                                            latency_bin_size_ns)
+    return matching_df.groupby('request_latency_ns').agg(count=('time_', px.count))
 
 
 # ----------------------------------------------------------------
@@ -145,9 +147,8 @@ def format_events_table(df, latency_ns_col):
 
     Returns: formatted events DataFrame
     """
-    df.latency_ms = df[latency_ns_col] / 1.0E6
-    df = df[df['latency_ms'] < 10000.0]
-    df.timestamp = px.bin(df.time_, px.seconds(window_s))
+    df = df[df[latency_ns_col] < (10000 * ns_per_ms)]
+    df.timestamp = px.bin(df.time_, window_ns)
     df[k8s_object] = df.ctx[k8s_object]
     df = df[df[k8s_object] != '']
     return df
@@ -176,7 +177,7 @@ def format_LET_aggs(df):
 
     Converts the result of aggregates on windows into well-formatted metrics that
     can be visualized. Latency quantile values need to be extracted from the
-    quantiles struct, and then error_rate, rps, and bytes_per_s are calculated as
+    quantiles struct, and then error_rate, requests_per_ns, and bytes_per_ns are calculated as
     a function of window size.
 
 
@@ -185,19 +186,18 @@ def format_LET_aggs(df):
 
     Args:
     @df: the input events table grouped into windows with aggregated
-        columns 'throughput_total', 'error_rate_per_window', and 'rps'
+        columns 'throughput_total', 'error_rate_per_window', and 'requests_per_ns'
 
     Returns: DataFrame with formatted LET metrics.
     """
-    window_size = window_s * 1.0
 
     df.latency_p50 = px.pluck_float64(df.latency_quantiles, 'p50')
     df.latency_p90 = px.pluck_float64(df.latency_quantiles, 'p90')
     df.latency_p99 = px.pluck_float64(df.latency_quantiles, 'p99')
     df['time_'] = df['timestamp']
-    df.rps = df.throughput_total / window_size
-    df.bytes_per_s = df.bytes_total / window_size
-    df.error_rate = df.error_rate_per_window * df.rps
+    df.requests_per_ns = df.throughput_total / window_ns
+    df.bytes_per_ns = df.bytes_total / window_ns
+    df.error_rate = df.error_rate_per_window * df.requests_per_ns / px.DurationNanos(1)
 
     return df
 
@@ -217,14 +217,14 @@ def calc_cql_LET(df, groups):
     """
     # All requests for errors and throughput
     et = df.groupby(groups).agg(
-        throughput_total=('latency_ms', px.count),
+        throughput_total=('latency_ns', px.count),
         error_rate_per_window=('failure', px.mean),
     )
 
     filt_df = df[df.resp_op != 0]
     # Calculate latency on all requests that return or return an err.
     lcy = filt_df.groupby(groups).agg(
-        latency_quantiles=('latency_ms', px.quantiles),
+        latency_quantiles=('latency_ns', px.quantiles),
         bytes_total=('resp_size', px.sum)
     )
     # Left join because et's groups are a strict superset of lcy.
@@ -266,8 +266,8 @@ def summarize_LET(let_df, groups):
     Returns: The summary DF.
     """
     df = let_df.groupby(groups).agg(
-        rps=('rps', px.mean),
-        bytes_per_s=('bytes_per_s', px.mean),
+        requests_per_ns=('requests_per_ns', px.mean),
+        bytes_per_ns=('bytes_per_ns', px.mean),
         error_rate=('error_rate', px.mean),
         total_requests=('throughput_total', px.sum),
         latency=('latency_p50', px.mean),

--- a/pxl_scripts/px/cql_stats/vis.json
+++ b/pxl_scripts/px/cql_stats/vis.json
@@ -53,7 +53,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "P50 Latency (ms)"
+          "label": "P50 Latency"
         },
         "xAxis": null
       }
@@ -79,7 +79,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "P90 Latency (ms)"
+          "label": "P90 Latency"
         },
         "xAxis": null
       }
@@ -97,7 +97,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "requests_per_ns",
+            "value": "request_throughput",
             "series": "k8s",
             "stackBySeries": false,
             "mode": "MODE_LINE"
@@ -154,13 +154,13 @@
       "displaySpec": {
         "@type": "pixielabs.ai/pl.vispb.HistogramChart",
         "histogram": {
-          "value": "request_latency_ns",
+          "value": "request_latency",
           "prebinCount": "count",
           "maxbins": 10,
           "minstep": 50.0
         },
         "xAxis": {
-          "label": "Request Latency (ms)"
+          "label": "Request Latency"
         },
         "yAxis": {
           "label": "# of requests"

--- a/pxl_scripts/px/cql_stats/vis.json
+++ b/pxl_scripts/px/cql_stats/vis.json
@@ -97,7 +97,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "rps",
+            "value": "requests_per_ns",
             "series": "k8s",
             "stackBySeries": false,
             "mode": "MODE_LINE"
@@ -154,7 +154,7 @@
       "displaySpec": {
         "@type": "pixielabs.ai/pl.vispb.HistogramChart",
         "histogram": {
-          "value": "request_latency_ms",
+          "value": "request_latency_ns",
           "prebinCount": "count",
           "maxbins": 10,
           "minstep": 50.0

--- a/pxl_scripts/px/http_data_filtered/data.pxl
+++ b/pxl_scripts/px/http_data_filtered/data.pxl
@@ -27,10 +27,9 @@ def http_data(start: str, svc: px.Service, pod: px.Pod, req_path: str):
                                                    'http_resp_body',
                                                    'http_resp_latency_ns'], start_time=start)
 
-    df.http_resp_latency_ms = df.http_resp_latency_ns / 1.0E6
     df.svc = df.ctx['service']
     df.pod = df.ctx['pod']
-    df = df.drop(columns=['http_resp_latency_ns', 'upid'])
+    df = df.drop(columns=['upid'])
 
     df = df[px.contains(df.svc, svc) and (px.contains(df.pod, pod)
                                           and px.contains(df.http_req_path, req_path))]

--- a/pxl_scripts/px/http_post_requests/data.pxl
+++ b/pxl_scripts/px/http_post_requests/data.pxl
@@ -28,9 +28,8 @@ df = px.DataFrame(table='http_events', select=['time_', 'upid', 'remote_addr', '
                                                'http_resp_latency_ns'], start_time=start_time)
 
 df = df[df.http_req_method == 'POST']
-df.http_resp_latency_ms = df.http_resp_latency_ns / 1.0E6
 df.service = df.ctx['service']
-df = df.drop(columns=['http_resp_latency_ns', 'upid'])
+df = df.drop(columns=['upid'])
 
 df = df[px.contains(df['service'], service_matcher)]
 df = df.head(n=max_num_records)

--- a/pxl_scripts/px/http_request_stats/stats.pxl
+++ b/pxl_scripts/px/http_request_stats/stats.pxl
@@ -8,7 +8,7 @@ t1 = px.DataFrame(table='http_events', start_time='-30s')
 t1.service = t1.ctx['service']
 t1.failure = t1.http_resp_status >= 400
 window = px.DurationNanos(px.seconds(5))
-t1.range_group = px.bin(t1.time_,  window)
+t1.range_group = px.bin(t1.time_, window)
 
 quantiles_agg = t1.groupby('service').agg(
     latency_quantiles=('http_resp_latency_ns', px.quantiles),

--- a/pxl_scripts/px/http_request_stats/stats.pxl
+++ b/pxl_scripts/px/http_request_stats/stats.pxl
@@ -7,7 +7,8 @@ t1 = px.DataFrame(table='http_events', start_time='-30s')
 
 t1.service = t1.ctx['service']
 t1.failure = t1.http_resp_status >= 400
-t1.range_group = t1.time_ - px.modulo(t1.time_, 1000000000)
+window = px.DurationNanos(px.seconds(5))
+t1.range_group = px.bin(t1.time_,  window)
 
 quantiles_agg = t1.groupby('service').agg(
     latency_quantiles=('http_resp_latency_ns', px.quantiles),
@@ -42,7 +43,7 @@ joined_table = quantiles_table.merge(rps_table,
 joined_table['latency(p50)'] = joined_table.latency_p50
 joined_table['latency(p90)'] = joined_table.latency_p90
 joined_table['latency(p99)'] = joined_table.latency_p99
-joined_table['throughput'] = joined_table.request_throughput
+joined_table['throughput'] = joined_table.request_throughput / window
 joined_table['throughput total'] = joined_table.throughput_total
 
 joined_table = joined_table[[

--- a/pxl_scripts/px/http_request_stats/stats.pxl
+++ b/pxl_scripts/px/http_request_stats/stats.pxl
@@ -14,10 +14,14 @@ quantiles_agg = t1.groupby('service').agg(
     errors=('failure', px.mean),
     throughput_total=('http_resp_status', px.count),
 )
+quantiles_agg.errors = px.Percent(quantiles_agg.errors)
 
-quantiles_agg.latency_p50 = px.pluck_float64(quantiles_agg.latency_quantiles, 'p50')
-quantiles_agg.latency_p90 = px.pluck_float64(quantiles_agg.latency_quantiles, 'p90')
-quantiles_agg.latency_p99 = px.pluck_float64(quantiles_agg.latency_quantiles, 'p99')
+quantiles_agg.latency_p50 = px.DurationNanos(px.floor(
+    px.pluck_float64(quantiles_agg.latency_quantiles, 'p50')))
+quantiles_agg.latency_p90 = px.DurationNanos(px.floor(
+    px.pluck_float64(quantiles_agg.latency_quantiles, 'p90')))
+quantiles_agg.latency_p99 = px.DurationNanos(px.floor(
+    px.pluck_float64(quantiles_agg.latency_quantiles, 'p99')))
 quantiles_table = quantiles_agg[['service', 'latency_p50',
                                  'latency_p90', 'latency_p99', 'errors', 'throughput_total']]
 
@@ -27,7 +31,7 @@ range_agg = t1.groupby(['service', 'range_group']).agg(
 )
 
 rps_table = range_agg.groupby('service').agg(
-    rps=('requests_per_window', px.mean))
+    request_throughput=('requests_per_window', px.mean))
 
 joined_table = quantiles_table.merge(rps_table,
                                      how='inner',
@@ -38,7 +42,7 @@ joined_table = quantiles_table.merge(rps_table,
 joined_table['latency(p50)'] = joined_table.latency_p50
 joined_table['latency(p90)'] = joined_table.latency_p90
 joined_table['latency(p99)'] = joined_table.latency_p99
-joined_table['throughput (rps)'] = joined_table.rps
+joined_table['throughput'] = joined_table.request_throughput
 joined_table['throughput total'] = joined_table.throughput_total
 
 joined_table = joined_table[[
@@ -47,7 +51,7 @@ joined_table = joined_table[[
     'latency(p90)',
     'latency(p99)',
     'errors',
-    'throughput (rps)',
+    'throughput',
     'throughput total']]
 joined_table = joined_table[joined_table.service != '']
 px.display(joined_table)

--- a/pxl_scripts/px/http_request_stats/stats.pxl
+++ b/pxl_scripts/px/http_request_stats/stats.pxl
@@ -6,12 +6,11 @@ import px
 t1 = px.DataFrame(table='http_events', start_time='-30s')
 
 t1.service = t1.ctx['service']
-t1.http_resp_latency_ms = t1.http_resp_latency_ns / 1.0E6
 t1.failure = t1.http_resp_status >= 400
 t1.range_group = t1.time_ - px.modulo(t1.time_, 1000000000)
 
 quantiles_agg = t1.groupby('service').agg(
-    latency_quantiles=('http_resp_latency_ms', px.quantiles),
+    latency_quantiles=('http_resp_latency_ns', px.quantiles),
     errors=('failure', px.mean),
     throughput_total=('http_resp_status', px.count),
 )

--- a/pxl_scripts/px/jvm_data/stats.pxl
+++ b/pxl_scripts/px/jvm_data/stats.pxl
@@ -10,6 +10,8 @@ df = px.DataFrame(table='jvm_stats', start_time='-1m')
 # Add additional fields
 df.pid = px.upid_to_pid(df.upid)
 df.cmdline = px.upid_to_cmdline(df.upid)
-
+df.used_heap_size = px.Bytes(df.used_heap_size)
+df.total_heap_size = px.Bytes(df.total_heap_size)
+df.max_heap_size = px.Bytes(df.max_heap_size)
 df = df[['time_', 'pid', 'used_heap_size', 'total_heap_size', 'max_heap_size', 'cmdline']]
 px.display(df)

--- a/pxl_scripts/px/jvm_data/stats.pxl
+++ b/pxl_scripts/px/jvm_data/stats.pxl
@@ -9,10 +9,7 @@ df = px.DataFrame(table='jvm_stats', start_time='-1m')
 
 # Add additional fields
 df.pid = px.upid_to_pid(df.upid)
-df.used_heap_size_mb = df.used_heap_size / bytes_per_mb
-df.total_heap_size_mb = df.total_heap_size / bytes_per_mb
-df.max_heap_size_mb = df.max_heap_size / bytes_per_mb
 df.cmdline = px.upid_to_cmdline(df.upid)
 
-df = df[['time_', 'pid', 'used_heap_size_mb', 'total_heap_size_mb', 'max_heap_size_mb', 'cmdline']]
+df = df[['time_', 'pid', 'used_heap_size', 'total_heap_size', 'max_heap_size', 'cmdline']]
 px.display(df)

--- a/pxl_scripts/px/jvm_stats/jvm_stats.pxl
+++ b/pxl_scripts/px/jvm_stats/jvm_stats.pxl
@@ -69,7 +69,7 @@ def jvm_stats(start: str, node_name: px.Node, pod: px.Pod):
     """
     df = filtered_process_stats(start, node_name, pod)
     # Calculate the CPU usage per window.
-    jvm_df = calculate_jvm(df, window_s)
+    jvm_df = calculate_jvm(df, window_ns)
     jvm_df[split_series_name] = jvm_df[k8s_object]
     return jvm_df
 
@@ -116,7 +116,7 @@ def filtered_process_stats(start: str, node_name: px.Node, pod: px.Pod):
     # Load and prepare the process_stats table to calculate CPU usage
     # by pod.
     process_df = px.DataFrame(table='jvm_stats', start_time=start)
-    process_df = format_jvm_table(process_df, window_s)
+    process_df = format_jvm_table(process_df, window_ns)
     process_df = filter_stats(process_df, node_name, pod)
     return process_df
 
@@ -215,6 +215,9 @@ def calculate_jvm(df, window_size):
 
     Returns: Calculated JVM stats per window and pod/svc.
     """
+    df.used_heap_size = px.Bytes(df.used_heap_size)
+    df.total_heap_size = px.Bytes(df.total_heap_size)
+    df.max_heap_size = px.Bytes(df.max_heap_size)
     # Aggregate over each UPID, k8s_object, and window.
     by_upid = df.groupby(['upid', k8s_object, 'timestamp']).agg(
         young_gc_time_max=('young_gc_time', px.max),
@@ -239,6 +242,8 @@ def calculate_jvm(df, window_size):
         max_heap_size=('max_heap_size', px.sum),
         total_heap_size=('total_heap_size', px.sum),
     )
+    per_k8s.young_gc_time = px.DurationNanos(per_k8s.young_gc_time)
+    per_k8s.full_gc_time = px.DurationNanos(per_k8s.full_gc_time)
 
     # Finally, calculate total (kernel + user time)  percentage used over window.
     per_k8s['time_'] = per_k8s['timestamp']

--- a/pxl_scripts/px/jvm_stats/jvm_stats.pxl
+++ b/pxl_scripts/px/jvm_stats/jvm_stats.pxl
@@ -19,13 +19,12 @@ import px
 # K8s object is the abstraction to group on.
 # Options are ['pod', 'service'].
 k8s_object = 'pod'
-# Window in seconds within which to aggregate metrics.
-window_s = 10
+ns_per_ms = 1000 * 1000
+ns_per_s = 1000 * ns_per_ms
+# Window size to use on time_ column for bucketing.
+window_ns = px.DurationNanos(10 * ns_per_s)
 # Name of the node column to display.
 node_col = 'node_name'
-# The number of bytes per megabyte. Saved as a variable to simplify
-# reuse.
-bytes_per_mb = 1024.0 * 1024.0
 
 split_series_name = 'k8s'
 px.Node = str
@@ -134,7 +133,7 @@ def format_stats_table(df, window_size):
 
     Returns: formatted stats DataFrame.
     """
-    df.timestamp = px.bin(df.time_, px.seconds(window_size))
+    df.timestamp = px.bin(df.time_, window_size)
     return df
 
 
@@ -154,17 +153,6 @@ def format_jvm_table(df, window_size):
     df = format_stats_table(df, window_size)
     df[node_col] = df.ctx['node_name']
     df[k8s_object] = df.ctx[k8s_object]
-
-    # # Convert bytes to MB.
-    # df.vsize_mb = df.vsize_bytes / bytes_per_mb
-    # df.rss_mb = df.rss_bytes / bytes_per_mb
-    df.used_heap_size = df.used_heap_size / bytes_per_mb
-    df.total_heap_size = df.total_heap_size / bytes_per_mb
-    df.max_heap_size = df.max_heap_size / bytes_per_mb
-
-    # Convert nanoseconds to milliseconds.
-    df.young_gc_time_ms = ((df.young_gc_time + df.time_) - df.time_) / 1.0E6
-    df.full_gc_time_ms = ((df.full_gc_time + df.time_) - df.time_) / 1.0E6
     return df
 
 
@@ -185,8 +173,6 @@ def format_network_table(df, window_size):
     df = format_stats_table(df, window_size)
     df[node_col] = px.pod_id_to_node_name(df.pod_id)
     df[k8s_object] = px.pod_id_to_pod_name(df.pod_id)
-    df.rx_mb = df.rx_bytes / bytes_per_mb
-    df.tx_mb = df.tx_bytes / bytes_per_mb
     return df
 
 
@@ -231,24 +217,24 @@ def calculate_jvm(df, window_size):
     """
     # Aggregate over each UPID, k8s_object, and window.
     by_upid = df.groupby(['upid', k8s_object, 'timestamp']).agg(
-        young_gc_time_ms_max=('young_gc_time_ms', px.max),
-        young_gc_time_ms_min=('young_gc_time_ms', px.min),
-        full_gc_time_ms_max=('full_gc_time_ms', px.max),
-        full_gc_time_ms_min=('full_gc_time_ms', px.min),
+        young_gc_time_max=('young_gc_time', px.max),
+        young_gc_time_min=('young_gc_time', px.min),
+        full_gc_time_max=('full_gc_time', px.max),
+        full_gc_time_min=('full_gc_time', px.min),
         used_heap_size=('used_heap_size', px.mean),
         total_heap_size=('total_heap_size', px.mean),
         max_heap_size=('max_heap_size', px.mean),
     )
 
     # Conver the counter metrics into accumulated values over the window.
-    by_upid.young_gc_time_ms = by_upid.young_gc_time_ms_max - by_upid.young_gc_time_ms_min
-    by_upid.full_gc_time_ms = by_upid.full_gc_time_ms_max - by_upid.full_gc_time_ms_min
+    by_upid.young_gc_time = by_upid.young_gc_time_max - by_upid.young_gc_time_min
+    by_upid.full_gc_time = by_upid.full_gc_time_max - by_upid.full_gc_time_min
 
     # Then aggregate process individual process metrics into the overall
     # k8s_object.
     per_k8s = by_upid.groupby([k8s_object, 'timestamp']).agg(
-        young_gc_time_ms=('young_gc_time_ms', px.sum),
-        full_gc_time_ms=('full_gc_time_ms', px.sum),
+        young_gc_time=('young_gc_time', px.sum),
+        full_gc_time=('full_gc_time', px.sum),
         used_heap_size=('used_heap_size', px.sum),
         max_heap_size=('max_heap_size', px.sum),
         total_heap_size=('total_heap_size', px.sum),

--- a/pxl_scripts/px/jvm_stats/vis.json
+++ b/pxl_scripts/px/jvm_stats/vis.json
@@ -55,7 +55,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "young_gc_time_ms",
+            "value": "young_gc_time",
             "series": "k8s",
             "stackBySeries": false,
             "mode": "MODE_LINE"
@@ -81,7 +81,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "full_gc_time_ms",
+            "value": "full_gc_time",
             "series": "k8s",
             "stackBySeries": false,
             "mode": "MODE_LINE"

--- a/pxl_scripts/px/jvm_stats/vis.json
+++ b/pxl_scripts/px/jvm_stats/vis.json
@@ -63,7 +63,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "Young GC Time (ms)"
+          "label": "Young GC Time"
         },
         "xAxis": null
       }
@@ -89,7 +89,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "Full GC Time (ms)"
+          "label": "Full GC Time"
         },
         "xAxis": null
       }

--- a/pxl_scripts/px/largest_http_request/data.pxl
+++ b/pxl_scripts/px/largest_http_request/data.pxl
@@ -30,7 +30,7 @@ def get_max_elm(df, column):
 
 df = px.DataFrame(table='http_events', start_time='-2m')
 
-df[resp_size] = px.length(df.http_resp_body)
+df[resp_size] = px.Bytes(px.length(df.http_resp_body))
 df[k8s_object] = df.ctx[k8s_object]
 filter_pods = px.contains(df[k8s_object], match_name)
 filter_out_conds = ((df.http_req_path != '/health' or not filter_health) and (

--- a/pxl_scripts/px/largest_http_request/data.pxl
+++ b/pxl_scripts/px/largest_http_request/data.pxl
@@ -8,7 +8,7 @@ import px
 ###############################################################
 # Pods/services are formatted as <namespace>/<name>.
 # If you want to match a namespace, only keep the namespace portion
-match_name = 'sock-shop'
+match_name = ''
 k8s_object = 'pod'
 
 # Visualization Variables - Dont change unless you know what you are doing

--- a/pxl_scripts/px/mysql_data/data.pxl
+++ b/pxl_scripts/px/mysql_data/data.pxl
@@ -7,7 +7,6 @@ t1 = px.DataFrame(table='mysql_events', select=['time_', 'remote_addr', 'remote_
                                                 'req_cmd', 'req_body', 'resp_status',
                                                 'resp_body', 'latency_ns'], start_time='-30s')
 
-t1.latency_ms = t1.latency_ns / 1.0E6
-t2 = t1.drop(columns=['latency_ns']).head(n=100)
+t2 = t1.head(n=100)
 
 px.display(t2)

--- a/pxl_scripts/px/mysql_stats/mysql_stats.pxl
+++ b/pxl_scripts/px/mysql_stats/mysql_stats.pxl
@@ -36,7 +36,7 @@ ip_col_name = 'MySQL IP'
 # Temporary way to ensure px.Pod works as expected.
 px.Pod = str
 # The bin size to use for the latency histogram.
-latency_bin_size_ns = px.DurationNanos(50 * ns_per_ms)
+latency_bin_size_ns = px.DurationNanos(5 * ns_per_ms)
 # ----------------------------------------------------------------
 
 
@@ -102,8 +102,8 @@ def latency_histogram(start: str, pod: px.Pod):
     # over the time window ('timestamp') after filtering for matching svcs.
     matching_df = df[px.contains(df[k8s_object], pod)]
 
-    matching_df.request_latency = px.bin(matching_df.latency,
-                                         latency_bin_size_ns)
+    matching_df.request_latency = px.DurationNanos(px.bin(matching_df.latency,
+                                                          latency_bin_size_ns))
     return matching_df.groupby('request_latency').agg(count=('time_', px.count))
 
 

--- a/pxl_scripts/px/mysql_stats/mysql_stats.pxl
+++ b/pxl_scripts/px/mysql_stats/mysql_stats.pxl
@@ -60,7 +60,7 @@ def pod_mysql_let(start: str, pod: px.Pod):
     """
     df = mysql_let_per_pod(start, pod, ['timestamp', k8s_object])
     return df['time_', split_series_name, 'latency_p50',
-              'latency_p90', 'latency_p99', 'error_rate', 'requests_per_ns']
+              'latency_p90', 'latency_p99', 'error_rate', 'request_throughput']
 
 
 def summary_mysql_let(start: str, pod: px.Pod):
@@ -78,7 +78,8 @@ def summary_mysql_let(start: str, pod: px.Pod):
     df = mysql_let_per_pod(start, pod, ['timestamp', k8s_object, 'remote_addr'])
     df[ip_col_name] = df.remote_addr
     summary_df = summarize_LET(df, [k8s_object, ip_col_name])
-    return summary_df[[k8s_object, ip_col_name, "requests_per_ns", "error_rate", "latency", "total_requests"]]
+    return summary_df[[k8s_object, ip_col_name, "request_throughput",
+                       "error_rate", "latency", "total_requests"]]
 
 
 def latency_histogram(start: str, pod: px.Pod):
@@ -101,9 +102,9 @@ def latency_histogram(start: str, pod: px.Pod):
     # over the time window ('timestamp') after filtering for matching svcs.
     matching_df = df[px.contains(df[k8s_object], pod)]
 
-    matching_df.request_latency_ns = px.bin(matching_df.latency_ns,
-                                            latency_bin_size_ns)
-    return matching_df.groupby('request_latency_ns').agg(count=('time_', px.count))
+    matching_df.request_latency = px.bin(matching_df.latency,
+                                         latency_bin_size_ns)
+    return matching_df.groupby('request_latency').agg(count=('time_', px.count))
 
 
 # ----------------------------------------------------------------
@@ -140,10 +141,10 @@ def mysql_let_per_pod(start: str, pod: px.Pod, groups):
     return let_df
 
 
-def format_events_table(df, latency_ns_col):
+def format_events_table(df, latency_col):
     """ Format data and add semantic columns in event tables
 
-    Unifies latency column to 'latency_ns', adds a binned
+    Unifies latency column to 'latency', adds a binned
     timestamp field to aggregate on, and adds the svc
     (k8s_object) as a semantic column.
 
@@ -151,12 +152,12 @@ def format_events_table(df, latency_ns_col):
 
     Args:
     @df: the input events table
-    @latency_ns_col: the name of the latency column in @df.
+    @latency_col: the name of the latency column in @df.
 
     Returns: formatted events DataFrame
     """
-    df.latency_ns = df[latency_ns_col]
-    df = df[df['latency_ns'] < (10000 * ns_per_ms)]
+    df.latency = df[latency_col]
+    df = df[df.latency < (10000 * ns_per_ms)]
     df.timestamp = px.bin(df.time_, window_ns)
     df[k8s_object] = df.ctx[k8s_object]
     df = df[df[k8s_object] != '']
@@ -180,7 +181,7 @@ def format_mysql_table(df, filter_responses_with_none_code):
     """
     df = format_events_table(df, 'latency_ns')
     df.failure = df['resp_status'] == 3
-    df.resp_size = px.length(df.resp_body)
+    df.resp_size = px.Bytes(px.length(df.resp_body))
 
     df = df[df.resp_status
             != none_response_code or not filter_responses_with_none_code]
@@ -192,7 +193,7 @@ def format_LET_aggs(df):
 
     Converts the result of aggregates on windows into well-formatted metrics that
     can be visualized. Latency quantile values need to be extracted from the
-    quantiles struct, and then error_rate, requests_per_ns, and bytes_per_ns are calculated as
+    quantiles struct, and then error_rate, request_throughput, and bytes_per_ns are calculated as
     a function of window size.
 
 
@@ -201,18 +202,18 @@ def format_LET_aggs(df):
 
     Args:
     @df: the input events table grouped into windows with aggregated
-        columns 'throughput_total', 'error_rate_per_window', and 'requests_per_ns'
+        columns 'throughput_total', 'error_rate_per_window', and 'request_throughput'
 
     Returns: DataFrame with formatted LET metrics.
     """
 
-    df.latency_p50 = px.pluck_float64(df.latency_quantiles, 'p50')
-    df.latency_p90 = px.pluck_float64(df.latency_quantiles, 'p90')
-    df.latency_p99 = px.pluck_float64(df.latency_quantiles, 'p99')
+    df.latency_p50 = px.DurationNanos(px.floor(px.pluck_float64(df.latency_quantiles, 'p50')))
+    df.latency_p90 = px.DurationNanos(px.floor(px.pluck_float64(df.latency_quantiles, 'p90')))
+    df.latency_p99 = px.DurationNanos(px.floor(px.pluck_float64(df.latency_quantiles, 'p99')))
     df['time_'] = df['timestamp']
-    df.requests_per_ns = df.throughput_total / window_ns
+    df.request_throughput = df.throughput_total / window_ns
     df.bytes_per_ns = df.bytes_total / window_ns
-    df.error_rate = df.error_rate_per_window * df.requests_per_ns / px.DurationNanos(1)
+    df.error_rate = df.error_rate_per_window * df.request_throughput / px.DurationNanos(1)
 
     return df
 
@@ -232,14 +233,14 @@ def calc_mysql_LET(df, groups):
     """
     # All requests for errors and throughput
     et = df.groupby(groups).agg(
-        throughput_total=('latency_ns', px.count),
+        throughput_total=('latency', px.count),
         error_rate_per_window=('failure', px.mean),
     )
 
     filt_df = df[df.resp_status != 1]
     # Calculate latency on all requests that return or return an err.
     lcy = filt_df.groupby(groups).agg(
-        latency_quantiles=('latency_ns', px.quantiles),
+        latency_quantiles=('latency', px.quantiles),
         bytes_total=('resp_size', px.sum)
     )
     # Left join because et's groups are a strict superset of lcy.
@@ -281,7 +282,7 @@ def summarize_LET(let_df, groups):
     Returns: The summary DF.
     """
     df = let_df.groupby(groups).agg(
-        requests_per_ns=('requests_per_ns', px.mean),
+        request_throughput=('request_throughput', px.mean),
         bytes_per_ns=('bytes_per_ns', px.mean),
         error_rate=('error_rate', px.mean),
         total_requests=('throughput_total', px.sum),

--- a/pxl_scripts/px/mysql_stats/mysql_stats.pxl
+++ b/pxl_scripts/px/mysql_stats/mysql_stats.pxl
@@ -19,8 +19,10 @@ import px
 # K8s object is the abstraction to group on.
 # Options are ['pod', 'service'].
 k8s_object = 'pod'
-# Window in seconds within which to aggregate metrics.
-window_s = 10
+ns_per_ms = 1000 * 1000
+ns_per_s = 1000 * ns_per_ms
+# Window size to use on time_ column for bucketing.
+window_ns = px.DurationNanos(10 * ns_per_s)
 # None response code returns on close() of MySQL connection.
 none_response_code = 1
 # Flag to filter out MySQL responses where no data is returned.
@@ -34,7 +36,7 @@ ip_col_name = 'MySQL IP'
 # Temporary way to ensure px.Pod works as expected.
 px.Pod = str
 # The bin size to use for the latency histogram.
-latency_bin_size_ms = 50
+latency_bin_size_ns = px.DurationNanos(50 * ns_per_ms)
 # ----------------------------------------------------------------
 
 
@@ -58,7 +60,7 @@ def pod_mysql_let(start: str, pod: px.Pod):
     """
     df = mysql_let_per_pod(start, pod, ['timestamp', k8s_object])
     return df['time_', split_series_name, 'latency_p50',
-              'latency_p90', 'latency_p99', 'error_rate', 'rps']
+              'latency_p90', 'latency_p99', 'error_rate', 'requests_per_ns']
 
 
 def summary_mysql_let(start: str, pod: px.Pod):
@@ -76,7 +78,7 @@ def summary_mysql_let(start: str, pod: px.Pod):
     df = mysql_let_per_pod(start, pod, ['timestamp', k8s_object, 'remote_addr'])
     df[ip_col_name] = df.remote_addr
     summary_df = summarize_LET(df, [k8s_object, ip_col_name])
-    return summary_df[[k8s_object, ip_col_name, "rps", "error_rate", "latency", "total_requests"]]
+    return summary_df[[k8s_object, ip_col_name, "requests_per_ns", "error_rate", "latency", "total_requests"]]
 
 
 def latency_histogram(start: str, pod: px.Pod):
@@ -99,9 +101,9 @@ def latency_histogram(start: str, pod: px.Pod):
     # over the time window ('timestamp') after filtering for matching svcs.
     matching_df = df[px.contains(df[k8s_object], pod)]
 
-    matching_df.request_latency_ms = px.bin(matching_df.latency_ns / 1000 / 1000,
-                                            latency_bin_size_ms)
-    return matching_df.groupby('request_latency_ms').agg(count=('time_', px.count))
+    matching_df.request_latency_ns = px.bin(matching_df.latency_ns,
+                                            latency_bin_size_ns)
+    return matching_df.groupby('request_latency_ns').agg(count=('time_', px.count))
 
 
 # ----------------------------------------------------------------
@@ -141,7 +143,7 @@ def mysql_let_per_pod(start: str, pod: px.Pod, groups):
 def format_events_table(df, latency_ns_col):
     """ Format data and add semantic columns in event tables
 
-    Unifies latency column to 'latency_ms', adds a binned
+    Unifies latency column to 'latency_ns', adds a binned
     timestamp field to aggregate on, and adds the svc
     (k8s_object) as a semantic column.
 
@@ -153,9 +155,9 @@ def format_events_table(df, latency_ns_col):
 
     Returns: formatted events DataFrame
     """
-    df.latency_ms = df[latency_ns_col] / 1.0E6
-    df = df[df['latency_ms'] < 10000.0]
-    df.timestamp = px.bin(df.time_, px.seconds(window_s))
+    df.latency_ns = df[latency_ns_col]
+    df = df[df['latency_ns'] < (10000 * ns_per_ms)]
+    df.timestamp = px.bin(df.time_, window_ns)
     df[k8s_object] = df.ctx[k8s_object]
     df = df[df[k8s_object] != '']
     return df
@@ -190,7 +192,7 @@ def format_LET_aggs(df):
 
     Converts the result of aggregates on windows into well-formatted metrics that
     can be visualized. Latency quantile values need to be extracted from the
-    quantiles struct, and then error_rate, rps, and bytes_per_s are calculated as
+    quantiles struct, and then error_rate, requests_per_ns, and bytes_per_ns are calculated as
     a function of window size.
 
 
@@ -199,19 +201,18 @@ def format_LET_aggs(df):
 
     Args:
     @df: the input events table grouped into windows with aggregated
-        columns 'throughput_total', 'error_rate_per_window', and 'rps'
+        columns 'throughput_total', 'error_rate_per_window', and 'requests_per_ns'
 
     Returns: DataFrame with formatted LET metrics.
     """
-    window_size = window_s * 1.0
 
     df.latency_p50 = px.pluck_float64(df.latency_quantiles, 'p50')
     df.latency_p90 = px.pluck_float64(df.latency_quantiles, 'p90')
     df.latency_p99 = px.pluck_float64(df.latency_quantiles, 'p99')
     df['time_'] = df['timestamp']
-    df.rps = df.throughput_total / window_size
-    df.bytes_per_s = df.bytes_total / window_size
-    df.error_rate = df.error_rate_per_window * df.rps
+    df.requests_per_ns = df.throughput_total / window_ns
+    df.bytes_per_ns = df.bytes_total / window_ns
+    df.error_rate = df.error_rate_per_window * df.requests_per_ns / px.DurationNanos(1)
 
     return df
 
@@ -231,14 +232,14 @@ def calc_mysql_LET(df, groups):
     """
     # All requests for errors and throughput
     et = df.groupby(groups).agg(
-        throughput_total=('latency_ms', px.count),
+        throughput_total=('latency_ns', px.count),
         error_rate_per_window=('failure', px.mean),
     )
 
     filt_df = df[df.resp_status != 1]
     # Calculate latency on all requests that return or return an err.
     lcy = filt_df.groupby(groups).agg(
-        latency_quantiles=('latency_ms', px.quantiles),
+        latency_quantiles=('latency_ns', px.quantiles),
         bytes_total=('resp_size', px.sum)
     )
     # Left join because et's groups are a strict superset of lcy.
@@ -280,8 +281,8 @@ def summarize_LET(let_df, groups):
     Returns: The summary DF.
     """
     df = let_df.groupby(groups).agg(
-        rps=('rps', px.mean),
-        bytes_per_s=('bytes_per_s', px.mean),
+        requests_per_ns=('requests_per_ns', px.mean),
+        bytes_per_ns=('bytes_per_ns', px.mean),
         error_rate=('error_rate', px.mean),
         total_requests=('throughput_total', px.sum),
         latency=('latency_p50', px.mean),

--- a/pxl_scripts/px/mysql_stats/vis.json
+++ b/pxl_scripts/px/mysql_stats/vis.json
@@ -53,7 +53,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "P50 Latency (ms)"
+          "label": "P50 Latency"
         },
         "xAxis": null
       }
@@ -79,7 +79,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "P90 Latency (ms)"
+          "label": "P90 Latency"
         },
         "xAxis": null
       }
@@ -97,7 +97,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "requests_per_ns",
+            "value": "request_throughput",
             "series": "k8s",
             "stackBySeries": false,
             "mode": "MODE_LINE"
@@ -105,7 +105,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "RPS"
+          "label": "Throughput"
         },
         "xAxis": null
       }
@@ -131,7 +131,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "Error Rate (%)"
+          "label": "Error Rate"
         },
         "xAxis": null
       }
@@ -154,13 +154,13 @@
       "displaySpec": {
         "@type": "pixielabs.ai/pl.vispb.HistogramChart",
         "histogram": {
-          "value": "request_latency_ns",
+          "value": "request_latency",
           "prebinCount": "count",
           "maxbins": 10,
           "minstep": 50.0
         },
         "xAxis": {
-          "label": "Request Latency (ms)"
+          "label": "Request Latency"
         },
         "yAxis": {
           "label": "# of requests"

--- a/pxl_scripts/px/mysql_stats/vis.json
+++ b/pxl_scripts/px/mysql_stats/vis.json
@@ -157,7 +157,7 @@
           "value": "request_latency",
           "prebinCount": "count",
           "maxbins": 10,
-          "minstep": 50.0
+          "minstep": 5000000
         },
         "xAxis": {
           "label": "Request Latency"

--- a/pxl_scripts/px/mysql_stats/vis.json
+++ b/pxl_scripts/px/mysql_stats/vis.json
@@ -97,7 +97,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "rps",
+            "value": "requests_per_ns",
             "series": "k8s",
             "stackBySeries": false,
             "mode": "MODE_LINE"
@@ -154,7 +154,7 @@
       "displaySpec": {
         "@type": "pixielabs.ai/pl.vispb.HistogramChart",
         "histogram": {
-          "value": "request_latency_ms",
+          "value": "request_latency_ns",
           "prebinCount": "count",
           "maxbins": 10,
           "minstep": 50.0

--- a/pxl_scripts/px/namespace/namespace.pxl
+++ b/pxl_scripts/px/namespace/namespace.pxl
@@ -53,32 +53,32 @@ def inbound_service_let_summary(start_time: str, namespace: px.Namespace):
     '''
     df = inbound_service_let_helper(start_time, namespace)
 
-    per_s_df = df.groupby(['timestamp', 'service']).agg(
-        throughput_total=('latency_ns', px.count),
+    per_ns_df = df.groupby(['timestamp', 'service']).agg(
+        throughput_total=('latency', px.count),
         inbound_bytes_total=('req_size', px.sum),
         outbound_bytes_total=('resp_size', px.sum)
     )
 
-    per_s_df.requests_per_ns = per_s_df.throughput_total / window_ns
-    per_s_df.inbound_bytes_per_ns = per_s_df.inbound_bytes_total / window_ns
-    per_s_df.outbound_bytes_per_ns = per_s_df.outbound_bytes_total / window_ns
+    per_ns_df.request_throughput = per_ns_df.throughput_total / window_ns
+    per_ns_df.inbound_throughput = per_ns_df.inbound_bytes_total / window_ns
+    per_ns_df.outbound_throughput = per_ns_df.outbound_bytes_total / window_ns
 
-    per_s_df = per_s_df.groupby(['service']).agg(
-        requests_per_ns=('requests_per_ns', px.mean),
-        inbound_bytes_per_ns=('inbound_bytes_per_ns', px.mean),
-        outbound_bytes_per_ns=('outbound_bytes_per_ns', px.mean)
+    per_ns_df = per_ns_df.groupby(['service']).agg(
+        request_throughput=('request_throughput', px.mean),
+        inbound_throughput=('inbound_throughput', px.mean),
+        outbound_throughput=('outbound_throughput', px.mean)
     )
 
     quantiles_df = df.groupby(['service']).agg(
-        latency_ns=('latency_ns', px.quantiles),
+        latency=('latency', px.quantiles),
         error_rate=('failure', px.mean)
     )
-    quantiles_df.error_rate_pct = px.Percent(quantiles_df.error_rate)
+    quantiles_df.error_rate = px.Percent(quantiles_df.error_rate)
 
-    joined = per_s_df.merge(quantiles_df, left_on='service', right_on='service', how='inner',
-                            suffixes=['', '_x'])
-    return joined[['service', 'latency_ns', 'requests_per_ns', 'error_rate_pct',
-                   'inbound_bytes_per_ns', 'outbound_bytes_per_ns']]
+    joined = per_ns_df.merge(quantiles_df, left_on='service', right_on='service', how='inner',
+                             suffixes=['', '_x'])
+    return joined[['service', 'latency', 'request_throughput', 'error_rate',
+                   'inbound_throughput', 'outbound_throughput']]
 
 
 def inbound_service_let_graph(start_time: str, namespace: px.Namespace):
@@ -93,9 +93,9 @@ def inbound_service_let_graph(start_time: str, namespace: px.Namespace):
     df = inbound_service_let_helper(start_time, namespace)
 
     df = df.groupby(['timestamp', 'service', 'remote_addr', 'pod']).agg(
-        latency_quantiles=('latency_ns', px.quantiles),
+        latency_quantiles=('latency', px.quantiles),
         error_rate=('failure', px.mean),
-        throughput_total=('latency_ns', px.count),
+        throughput_total=('latency', px.count),
         inbound_bytes_total=('req_size', px.sum),
         outbound_bytes_total=('resp_size', px.sum)
     )
@@ -111,20 +111,20 @@ def inbound_service_let_graph(start_time: str, namespace: px.Namespace):
     df.responder_service = df.service
     df.requestor_service = px.pod_id_to_service_name(df.requestor_pod_id)
 
-    df.requests_per_ns = df.throughput_total / window_ns
-    df.inbound_bytes_per_ns = df.inbound_bytes_total / window_ns
-    df.outbound_bytes_per_ns = df.outbound_bytes_total / window_ns
-    df.error_rate_pct = px.Percent(df.error_rate)
+    df.request_throughput = df.throughput_total / window_ns
+    df.inbound_throughput = df.inbound_bytes_total / window_ns
+    df.outbound_throughput = df.outbound_bytes_total / window_ns
+    df.error_rate = px.Percent(df.error_rate)
 
     return df.groupby(['responder_pod', 'requestor_pod', 'responder_service',
                        'requestor_service']).agg(
         latency_p50=('latency_p50', px.mean),
         latency_p90=('latency_p90', px.mean),
         latency_p99=('latency_p99', px.mean),
-        requests_per_ns=('requests_per_ns', px.mean),
-        error_rate_pct=('error_rate_pct', px.mean),
-        inbound_bytes_per_ns=('inbound_bytes_per_ns', px.mean),
-        outbound_bytes_per_ns=('outbound_bytes_per_ns', px.mean),
+        request_throughput=('request_throughput', px.mean),
+        error_rate=('error_rate', px.mean),
+        inbound_throughput=('inbound_throughput', px.mean),
+        outbound_throughput=('outbound_throughput', px.mean),
         throughput_total=('throughput_total', px.sum)
     )
 
@@ -141,8 +141,8 @@ def inbound_service_let_helper(start_time: str, namespace: px.Namespace):
     df.service = df.ctx['service']
     df.pod = df.ctx['pod_name']
     df = df[df.ctx['namespace'] == namespace and df.service != '']
-    df.latency_ns = df.http_resp_latency_ns
-    df = df[df['latency_ns'] < (10000 * ns_per_ms)]
+    df.latency = df.http_resp_latency_ns
+    df = df[df['latency'] < (10000 * ns_per_ms)]
     df.timestamp = px.bin(df.time_, window_ns)
 
     df.req_size = px.Bytes(px.length(df.http_req_body))
@@ -154,5 +154,3 @@ def inbound_service_let_helper(start_time: str, namespace: px.Namespace):
 
     df = df[filter_out_conds]
     return df
-
-px.display(inbound_service_let_summary('-10s', 'pl'))

--- a/pxl_scripts/px/namespace/namespace.pxl
+++ b/pxl_scripts/px/namespace/namespace.pxl
@@ -10,16 +10,17 @@ as well as a service map.
 
 import px
 
-# Nanoseconds per second.
-ns_per_ms = 1.0E6
+
 # Flag to filter out requests that come from an unresolvable IP.
 filter_unresolved_inbound = True
 # Flag to filter out health checks from the data.
 filter_health_checks = True
 # Flag to filter out ready checks from the data.
 filter_ready_checks = True
+ns_per_ms = 1000 * 1000
+ns_per_s = 1000 * ns_per_ms
 # Window size to use on time_ column for bucketing.
-window_s = 10
+window_ns = px.DurationNanos(10 * ns_per_s)
 
 
 def pods_for_namespace(start_time: str, namespace: px.Namespace):
@@ -53,32 +54,31 @@ def inbound_service_let_summary(start_time: str, namespace: px.Namespace):
     df = inbound_service_let_helper(start_time, namespace)
 
     per_s_df = df.groupby(['timestamp', 'service']).agg(
-        throughput_total=('latency_ms', px.count),
+        throughput_total=('latency_ns', px.count),
         inbound_bytes_total=('req_size', px.sum),
         outbound_bytes_total=('resp_size', px.sum)
     )
 
-    window_size = 1.0 * window_s
-    per_s_df.requests_per_s = per_s_df.throughput_total / window_size
-    per_s_df.inbound_bytes_per_s = per_s_df.inbound_bytes_total / window_size
-    per_s_df.outbound_bytes_per_s = per_s_df.outbound_bytes_total / window_size
+    per_s_df.requests_per_ns = per_s_df.throughput_total / window_ns
+    per_s_df.inbound_bytes_per_ns = per_s_df.inbound_bytes_total / window_ns
+    per_s_df.outbound_bytes_per_ns = per_s_df.outbound_bytes_total / window_ns
 
     per_s_df = per_s_df.groupby(['service']).agg(
-        requests_per_s=('requests_per_s', px.mean),
-        inbound_bytes_per_s=('inbound_bytes_per_s', px.mean),
-        outbound_bytes_per_s=('outbound_bytes_per_s', px.mean)
+        requests_per_ns=('requests_per_ns', px.mean),
+        inbound_bytes_per_ns=('inbound_bytes_per_ns', px.mean),
+        outbound_bytes_per_ns=('outbound_bytes_per_ns', px.mean)
     )
 
     quantiles_df = df.groupby(['service']).agg(
-        latency_ms=('latency_ms', px.quantiles),
+        latency_ns=('latency_ns', px.quantiles),
         error_rate=('failure', px.mean)
     )
-    quantiles_df.error_rate_pct = quantiles_df.error_rate * 100 / window_size
+    quantiles_df.error_rate_pct = px.Percent(quantiles_df.error_rate)
 
     joined = per_s_df.merge(quantiles_df, left_on='service', right_on='service', how='inner',
                             suffixes=['', '_x'])
-    return joined[['service', 'latency_ms', 'requests_per_s', 'error_rate_pct',
-                   'inbound_bytes_per_s', 'outbound_bytes_per_s']]
+    return joined[['service', 'latency_ns', 'requests_per_ns', 'error_rate_pct',
+                   'inbound_bytes_per_ns', 'outbound_bytes_per_ns']]
 
 
 def inbound_service_let_graph(start_time: str, namespace: px.Namespace):
@@ -93,9 +93,9 @@ def inbound_service_let_graph(start_time: str, namespace: px.Namespace):
     df = inbound_service_let_helper(start_time, namespace)
 
     df = df.groupby(['timestamp', 'service', 'remote_addr', 'pod']).agg(
-        latency_quantiles=('latency_ms', px.quantiles),
+        latency_quantiles=('latency_ns', px.quantiles),
         error_rate=('failure', px.mean),
-        throughput_total=('latency_ms', px.count),
+        throughput_total=('latency_ns', px.count),
         inbound_bytes_total=('req_size', px.sum),
         outbound_bytes_total=('resp_size', px.sum)
     )
@@ -111,21 +111,20 @@ def inbound_service_let_graph(start_time: str, namespace: px.Namespace):
     df.responder_service = df.service
     df.requestor_service = px.pod_id_to_service_name(df.requestor_pod_id)
 
-    window_size = 1.0 * window_s
-    df.requests_per_s = df.throughput_total / window_size
-    df.inbound_bytes_per_s = df.inbound_bytes_total / window_size
-    df.outbound_bytes_per_s = df.outbound_bytes_total / window_size
-    df.error_rate_pct = df.error_rate * 100 / window_size
+    df.requests_per_ns = df.throughput_total / window_ns
+    df.inbound_bytes_per_ns = df.inbound_bytes_total / window_ns
+    df.outbound_bytes_per_ns = df.outbound_bytes_total / window_ns
+    df.error_rate_pct = px.Percent(df.error_rate)
 
     return df.groupby(['responder_pod', 'requestor_pod', 'responder_service',
                        'requestor_service']).agg(
         latency_p50=('latency_p50', px.mean),
         latency_p90=('latency_p90', px.mean),
         latency_p99=('latency_p99', px.mean),
-        requests_per_s=('requests_per_s', px.mean),
+        requests_per_ns=('requests_per_ns', px.mean),
         error_rate_pct=('error_rate_pct', px.mean),
-        inbound_bytes_per_s=('inbound_bytes_per_s', px.mean),
-        outbound_bytes_per_s=('outbound_bytes_per_s', px.mean),
+        inbound_bytes_per_ns=('inbound_bytes_per_ns', px.mean),
+        outbound_bytes_per_ns=('outbound_bytes_per_ns', px.mean),
         throughput_total=('throughput_total', px.sum)
     )
 
@@ -142,12 +141,12 @@ def inbound_service_let_helper(start_time: str, namespace: px.Namespace):
     df.service = df.ctx['service']
     df.pod = df.ctx['pod_name']
     df = df[df.ctx['namespace'] == namespace and df.service != '']
-    df.latency_ms = df.http_resp_latency_ns / 1.0E6
-    df = df[df['latency_ms'] < 10000.0]
-    df.timestamp = px.bin(df.time_, px.seconds(window_s))
+    df.latency_ns = df.http_resp_latency_ns
+    df = df[df['latency_ns'] < (10000 * ns_per_ms)]
+    df.timestamp = px.bin(df.time_, window_ns)
 
-    df.req_size = px.length(df.http_req_body)
-    df.resp_size = px.length(df.http_resp_body)
+    df.req_size = px.Bytes(px.length(df.http_req_body))
+    df.resp_size = px.Bytes(px.length(df.http_resp_body))
     df.failure = df.http_resp_status >= 400
     filter_out_conds = ((df.http_req_path != '/health' or not filter_health_checks) and (
         df.http_req_path != '/readyz' or not filter_ready_checks)) and (
@@ -155,3 +154,5 @@ def inbound_service_let_helper(start_time: str, namespace: px.Namespace):
 
     df = df[filter_out_conds]
     return df
+
+px.display(inbound_service_let_summary('-10s', 'pl'))

--- a/pxl_scripts/px/namespace/vis.json
+++ b/pxl_scripts/px/namespace/vis.json
@@ -44,10 +44,10 @@
         "p50Column": "latency_p50",
         "p90Column": "latency_p90",
         "p99Column": "latency_p99",
-        "errorRateColumn": "error_rate_pct",
-        "requestsPerSecondColumn": "requests_per_ns",
-        "inboundBytesPerSecondColumn": "inbound_bytes_per_ns",
-        "outboundBytesPerSecondColumn": "outbound_bytes_per_ns",
+        "errorRateColumn": "error_rate",
+        "requestsPerSecondColumn": "request_throughput",
+        "inboundBytesPerSecondColumn": "inbound_throughput",
+        "outboundBytesPerSecondColumn": "outbound_throughput",
         "totalRequestCountColumn": "throughput_total"
       }
     },

--- a/pxl_scripts/px/namespace/vis.json
+++ b/pxl_scripts/px/namespace/vis.json
@@ -45,9 +45,9 @@
         "p90Column": "latency_p90",
         "p99Column": "latency_p99",
         "errorRateColumn": "error_rate_pct",
-        "requestsPerSecondColumn": "requests_per_s",
-        "inboundBytesPerSecondColumn": "inbound_bytes_per_s",
-        "outboundBytesPerSecondColumn": "outbound_bytes_per_s",
+        "requestsPerSecondColumn": "requests_per_ns",
+        "inboundBytesPerSecondColumn": "inbound_bytes_per_ns",
+        "outboundBytesPerSecondColumn": "outbound_bytes_per_ns",
         "totalRequestCountColumn": "throughput_total"
       }
     },

--- a/pxl_scripts/px/namespaces/namespaces.pxl
+++ b/pxl_scripts/px/namespaces/namespaces.pxl
@@ -47,8 +47,8 @@ def process_stats_by_namespace(start_time: str):
     df.timestamp = px.bin(df.time_, window_ns)
 
     df = df.groupby(['upid', 'namespace', 'timestamp']).agg(
-        vsize_bytes=('vsize_bytes', px.mean),
-        rss_bytes=('rss_bytes', px.mean),
+        vsize=('vsize_bytes', px.mean),
+        rss=('rss_bytes', px.mean),
         read_bytes_max=('read_bytes', px.max),
         read_bytes_min=('read_bytes', px.min),
         write_bytes_max=('write_bytes', px.max),
@@ -68,27 +68,27 @@ def process_stats_by_namespace(start_time: str):
     # For this aggregate, we sum up the values as we've already calculated the average/usage
     # for the upids already.
     df = df.groupby(['namespace', 'timestamp']).agg(
-        vsize_bytes=('vsize_bytes', px.sum),
-        rss_bytes=('rss_bytes', px.sum),
+        vsize=('vsize', px.sum),
+        rss=('rss', px.sum),
         read_bytes=('read_bytes', px.sum),
         write_bytes=('write_bytes', px.sum),
         rchar_bytes=('rchar_bytes', px.sum),
         wchar_bytes=('wchar_bytes', px.sum),
     )
 
-    df.read_bytes_per_ns = df.read_bytes / window_ns
-    df.write_bytes_per_ns = df.write_bytes / window_ns
-    df.rchar_bytes_per_ns = df.rchar_bytes / window_ns
-    df.wchar_bytes_per_ns = df.wchar_bytes / window_ns
+    df.actual_disk_read_throughput = df.read_bytes / window_ns
+    df.actual_disk_write_throughput = df.write_bytes / window_ns
+    df.total_disk_read_throughput = df.rchar_bytes / window_ns
+    df.total_disk_write_throughput = df.wchar_bytes / window_ns
 
     # Finally, we get the mean value across the total time window.
     df = df.groupby('namespace').agg(
-        avg_vsize_bytes=('vsize_bytes', px.mean),
-        avg_rss_bytes=('rss_bytes', px.mean),
-        read_bytes_per_ns=('read_bytes_per_ns', px.mean),
-        write_bytes_per_ns=('write_bytes_per_ns', px.mean),
-        rchar_bytes_per_ns=('rchar_bytes_per_ns', px.mean),
-        wchar_bytes_per_ns=('wchar_bytes_per_ns', px.mean),
+        avg_vsize=('vsize', px.mean),
+        avg_rss=('rss', px.mean),
+        actual_disk_read_throughput=('actual_disk_read_throughput', px.mean),
+        actual_disk_write_throughput=('actual_disk_write_throughput', px.mean),
+        total_disk_read_throughput=('total_disk_read_throughput', px.mean),
+        total_disk_write_throughput=('total_disk_write_throughput', px.mean),
     )
 
     return df

--- a/pxl_scripts/px/namespaces/namespaces.pxl
+++ b/pxl_scripts/px/namespaces/namespaces.pxl
@@ -10,9 +10,10 @@ It also lists the high-level resource consumption by namespace.
 
 import px
 
-bytes_per_mb = 1024.0 * 1024.0
+ns_per_ms = 1000 * 1000
+ns_per_s = 1000 * ns_per_ms
 # Window size to use on time_ column for bucketing.
-window_s = 10
+window_ns = px.DurationNanos(10 * ns_per_s)
 
 
 def namespaces_for_cluster(start_time: str):
@@ -43,60 +44,51 @@ def process_stats_by_namespace(start_time: str):
 
     df = px.DataFrame(table='process_stats', start_time=start_time)
     df.namespace = df.ctx['namespace']
-    df.timestamp = px.bin(df.time_, px.seconds(window_s))
-
-    # Convert to MB.
-    df.vsize_mb = df.vsize_bytes / bytes_per_mb
-    df.rss_mb = df.rss_bytes / bytes_per_mb
-    df.read_mb = df.read_bytes / bytes_per_mb
-    df.write_mb = df.write_bytes / bytes_per_mb
-    df.rchar_mb = df.rchar_bytes / bytes_per_mb
-    df.wchar_mb = df.wchar_bytes / bytes_per_mb
+    df.timestamp = px.bin(df.time_, window_ns)
 
     df = df.groupby(['upid', 'namespace', 'timestamp']).agg(
-        vsize_mb=('vsize_mb', px.mean),
-        rss_mb=('rss_mb', px.mean),
-        read_mb_max=('read_mb', px.max),
-        read_mb_min=('read_mb', px.min),
-        write_mb_max=('write_mb', px.max),
-        write_mb_min=('write_mb', px.min),
-        rchar_mb_max=('rchar_mb', px.max),
-        rchar_mb_min=('rchar_mb', px.min),
-        wchar_mb_max=('wchar_mb', px.max),
-        wchar_mb_min=('wchar_mb', px.min),
+        vsize_bytes=('vsize_bytes', px.mean),
+        rss_bytes=('rss_bytes', px.mean),
+        read_bytes_max=('read_bytes', px.max),
+        read_bytes_min=('read_bytes', px.min),
+        write_bytes_max=('write_bytes', px.max),
+        write_bytes_min=('write_bytes', px.min),
+        rchar_bytes_max=('rchar_bytes', px.max),
+        rchar_bytes_min=('rchar_bytes', px.min),
+        wchar_bytes_max=('wchar_bytes', px.max),
+        wchar_bytes_min=('wchar_bytes', px.min),
     )
 
     # Deltas computed across 1 time window
-    df.read_mb = df.read_mb_max - df.read_mb_min
-    df.write_mb = df.write_mb_max - df.write_mb_min
-    df.rchar_mb = df.rchar_mb_max - df.rchar_mb_min
-    df.wchar_mb = df.wchar_mb_max - df.wchar_mb_min
+    df.read_bytes = df.read_bytes_max - df.read_bytes_min
+    df.write_bytes = df.write_bytes_max - df.write_bytes_min
+    df.rchar_bytes = df.rchar_bytes_max - df.rchar_bytes_min
+    df.wchar_bytes = df.wchar_bytes_max - df.wchar_bytes_min
 
     # For this aggregate, we sum up the values as we've already calculated the average/usage
     # for the upids already.
     df = df.groupby(['namespace', 'timestamp']).agg(
-        vsize_mb=('vsize_mb', px.sum),
-        rss_mb=('rss_mb', px.sum),
-        read_mb=('read_mb', px.sum),
-        write_mb=('write_mb', px.sum),
-        rchar_mb=('rchar_mb', px.sum),
-        wchar_mb=('wchar_mb', px.sum),
+        vsize_bytes=('vsize_bytes', px.sum),
+        rss_bytes=('rss_bytes', px.sum),
+        read_bytes=('read_bytes', px.sum),
+        write_bytes=('write_bytes', px.sum),
+        rchar_bytes=('rchar_bytes', px.sum),
+        wchar_bytes=('wchar_bytes', px.sum),
     )
 
-    window_size = 1.0 * window_s
-    df.read_mb_per_s = df.read_mb / window_size
-    df.write_mb_per_s = df.write_mb / window_size
-    df.rchar_mb_per_s = df.rchar_mb / window_size
-    df.wchar_mb_per_s = df.wchar_mb / window_size
+    df.read_bytes_per_ns = df.read_bytes / window_ns
+    df.write_bytes_per_ns = df.write_bytes / window_ns
+    df.rchar_bytes_per_ns = df.rchar_bytes / window_ns
+    df.wchar_bytes_per_ns = df.wchar_bytes / window_ns
 
     # Finally, we get the mean value across the total time window.
     df = df.groupby('namespace').agg(
-        avg_vsize_mb=('vsize_mb', px.mean),
-        avg_rss_mb=('rss_mb', px.mean),
-        read_mb_per_s=('read_mb_per_s', px.mean),
-        write_mb_per_s=('write_mb_per_s', px.mean),
-        rchar_mb_per_s=('rchar_mb_per_s', px.mean),
-        wchar_mb_per_s=('wchar_mb_per_s', px.mean),
+        avg_vsize_bytes=('vsize_bytes', px.mean),
+        avg_rss_bytes=('rss_bytes', px.mean),
+        read_bytes_per_ns=('read_bytes_per_ns', px.mean),
+        write_bytes_per_ns=('write_bytes_per_ns', px.mean),
+        rchar_bytes_per_ns=('rchar_bytes_per_ns', px.mean),
+        wchar_bytes_per_ns=('wchar_bytes_per_ns', px.mean),
     )
 
     return df

--- a/pxl_scripts/px/node/node.pxl
+++ b/pxl_scripts/px/node/node.pxl
@@ -46,20 +46,16 @@ def resource_timeseries(start_time: str, node: px.Node, groupby: str):
     df[groupby] = df.ctx[groupby]
     df.timestamp = px.bin(df.time_, window_ns)
 
-    # Convert nanoseconds to milliseconds.
-    df.cpu_utime_ms = df.cpu_utime_ns / 1.0E6
-    df.cpu_ktime_ms = df.cpu_ktime_ns / 1.0E6
-
     # First calculate CPU usage by process (UPID) in each k8s_object
     # over all windows.
     df = df.groupby(['upid', 'timestamp', groupby]).agg(
-        rss_bytes=('rss_bytes', px.mean),
-        vsize_bytes=('vsize_bytes', px.mean),
+        rss=('rss_bytes', px.mean),
+        vsize=('vsize_bytes', px.mean),
         # The fields below are counters, so we take the min and the max to subtract them.
-        cpu_utime_ms_max=('cpu_utime_ms', px.max),
-        cpu_utime_ms_min=('cpu_utime_ms', px.min),
-        cpu_ktime_ms_max=('cpu_ktime_ms', px.max),
-        cpu_ktime_ms_min=('cpu_ktime_ms', px.min),
+        cpu_utime_ns_max=('cpu_utime_ns', px.max),
+        cpu_utime_ns_min=('cpu_utime_ns', px.min),
+        cpu_ktime_ns_max=('cpu_ktime_ns', px.max),
+        cpu_ktime_ns_min=('cpu_ktime_ns', px.min),
         read_bytes_max=('read_bytes', px.max),
         read_bytes_min=('read_bytes', px.min),
         write_bytes_max=('write_bytes', px.max),
@@ -70,32 +66,30 @@ def resource_timeseries(start_time: str, node: px.Node, groupby: str):
         wchar_bytes_min=('wchar_bytes', px.min),
     )
     # Next calculate cpu usage and memory stats per window.
-    df.cpu_utime_ms = df.cpu_utime_ms_max - df.cpu_utime_ms_min
-    df.cpu_ktime_ms = df.cpu_ktime_ms_max - df.cpu_ktime_ms_min
-    df.read_bytes_per_ns = (df.read_bytes_max - df.read_bytes_min) / window_ns
-    df.write_bytes_per_ns = (df.write_bytes_max - df.write_bytes_min) / window_ns
-    df.rchar_bytes_per_ns = (df.rchar_bytes_max - df.rchar_bytes_min) / window_ns
-    df.wchar_bytes_per_ns = (df.wchar_bytes_max - df.wchar_bytes_min) / window_ns
+    df.cpu_utime_ns = df.cpu_utime_ns_max - df.cpu_utime_ns_min
+    df.cpu_ktime_ns = df.cpu_ktime_ns_max - df.cpu_ktime_ns_min
+    df.actual_disk_read_throughput = (df.read_bytes_max - df.read_bytes_min) / window_ns
+    df.actual_disk_write_throughput = (df.write_bytes_max - df.write_bytes_min) / window_ns
+    df.total_disk_read_throughput = (df.rchar_bytes_max - df.rchar_bytes_min) / window_ns
+    df.total_disk_write_throughput = (df.wchar_bytes_max - df.wchar_bytes_min) / window_ns
 
     # Then aggregate process individual process metrics.
     df = df.groupby(['timestamp', groupby]).agg(
-        cpu_ktime_ms=('cpu_ktime_ms', px.sum),
-        cpu_utime_ms=('cpu_utime_ms', px.sum),
-        read_bytes_per_ns=('read_bytes_per_ns', px.sum),
-        write_bytes_per_ns=('write_bytes_per_ns', px.sum),
-        rchar_bytes_per_ns=('rchar_bytes_per_ns', px.sum),
-        wchar_bytes_per_ns=('wchar_bytes_per_ns', px.sum),
-        rss_bytes=('rss_bytes', px.sum),
-        vsize_bytes=('vsize_bytes', px.sum),
+        cpu_ktime_ns=('cpu_ktime_ns', px.sum),
+        cpu_utime_ns=('cpu_utime_ns', px.sum),
+        actual_disk_read_throughput=('actual_disk_read_throughput', px.sum),
+        actual_disk_write_throughput=('actual_disk_write_throughput', px.sum),
+        total_disk_read_throughput=('total_disk_read_throughput', px.sum),
+        total_disk_write_throughput=('total_disk_write_throughput', px.sum),
+        rss=('rss', px.sum),
+        vsize=('vsize', px.sum),
     )
 
-    # Convert window_ns into the same units as cpu time.
-    window_size_ms = window_ns * 1.0E3
     # Finally, calculate total (kernel + user time)  percentage used over window.
-    df.cpu_pct = (df.cpu_ktime_ms + df.cpu_utime_ms) / window_size_ms * 100
+    df.cpu_usage = px.Percent((df.cpu_ktime_ns + df.cpu_utime_ns) / window_ns)
     df['time_'] = df['timestamp']
     df.groupby_col = df[groupby]
-    return df.drop(['cpu_ktime_ms', 'cpu_utime_ms', 'timestamp', groupby])
+    return df.drop(['cpu_ktime_ns', 'cpu_utime_ns', 'timestamp', groupby])
 
 
 def network_stats(start_time: str, node: px.Node, groupby: str):

--- a/pxl_scripts/px/node/node.pxl
+++ b/pxl_scripts/px/node/node.pxl
@@ -10,9 +10,10 @@ It also displays a list of pods that were on that node during the time window.
 '''
 import px
 
-
-window_s = 10
-bytes_per_mb = 1024.0 * 1024.0
+ns_per_ms = 1000 * 1000
+ns_per_s = 1000 * ns_per_ms
+# Window size to use on time_ column for bucketing.
+window_ns = px.DurationNanos(10 * ns_per_s)
 
 
 def pods_for_node(start_time: str, node: px.Node):
@@ -42,17 +43,8 @@ def resource_timeseries(start_time: str, node: px.Node, groupby: str):
     '''
     df = px.DataFrame(table='process_stats', start_time=start_time)
     df = df[df.ctx['node_name'] == node]
-
     df[groupby] = df.ctx[groupby]
-    df.timestamp = px.bin(df.time_, px.seconds(window_s))
-
-    # Convert bytes to MB.
-    df.vsize_mb = df.vsize_bytes / bytes_per_mb
-    df.rss_mb = df.rss_bytes / bytes_per_mb
-    df.read_mb = df.read_bytes / bytes_per_mb
-    df.write_mb = df.write_bytes / bytes_per_mb
-    df.rchar_mb = df.rchar_bytes / bytes_per_mb
-    df.wchar_mb = df.wchar_bytes / bytes_per_mb
+    df.timestamp = px.bin(df.time_, window_ns)
 
     # Convert nanoseconds to milliseconds.
     df.cpu_utime_ms = df.cpu_utime_ns / 1.0E6
@@ -61,45 +53,44 @@ def resource_timeseries(start_time: str, node: px.Node, groupby: str):
     # First calculate CPU usage by process (UPID) in each k8s_object
     # over all windows.
     df = df.groupby(['upid', 'timestamp', groupby]).agg(
-        rss_mb=('rss_mb', px.mean),
-        vsize_mb=('vsize_mb', px.mean),
+        rss_bytes=('rss_bytes', px.mean),
+        vsize_bytes=('vsize_bytes', px.mean),
         # The fields below are counters, so we take the min and the max to subtract them.
         cpu_utime_ms_max=('cpu_utime_ms', px.max),
         cpu_utime_ms_min=('cpu_utime_ms', px.min),
         cpu_ktime_ms_max=('cpu_ktime_ms', px.max),
         cpu_ktime_ms_min=('cpu_ktime_ms', px.min),
-        read_mb_max=('read_mb', px.max),
-        read_mb_min=('read_mb', px.min),
-        write_mb_max=('write_mb', px.max),
-        write_mb_min=('write_mb', px.min),
-        rchar_mb_max=('rchar_mb', px.max),
-        rchar_mb_min=('rchar_mb', px.min),
-        wchar_mb_max=('wchar_mb', px.max),
-        wchar_mb_min=('wchar_mb', px.min),
+        read_bytes_max=('read_bytes', px.max),
+        read_bytes_min=('read_bytes', px.min),
+        write_bytes_max=('write_bytes', px.max),
+        write_bytes_min=('write_bytes', px.min),
+        rchar_bytes_max=('rchar_bytes', px.max),
+        rchar_bytes_min=('rchar_bytes', px.min),
+        wchar_bytes_max=('wchar_bytes', px.max),
+        wchar_bytes_min=('wchar_bytes', px.min),
     )
-    window_size = 1.0 * window_s
     # Next calculate cpu usage and memory stats per window.
     df.cpu_utime_ms = df.cpu_utime_ms_max - df.cpu_utime_ms_min
     df.cpu_ktime_ms = df.cpu_ktime_ms_max - df.cpu_ktime_ms_min
-    df.read_mb_per_s = (df.read_mb_max - df.read_mb_min) / window_size
-    df.write_mb_per_s = (df.write_mb_max - df.write_mb_min) / window_size
-    df.rchar_mb_per_s = (df.rchar_mb_max - df.rchar_mb_min) / window_size
-    df.wchar_mb_per_s = (df.wchar_mb_max - df.wchar_mb_min) / window_size
+    df.read_bytes_per_ns = (df.read_bytes_max - df.read_bytes_min) / window_ns
+    df.write_bytes_per_ns = (df.write_bytes_max - df.write_bytes_min) / window_ns
+    df.rchar_bytes_per_ns = (df.rchar_bytes_max - df.rchar_bytes_min) / window_ns
+    df.wchar_bytes_per_ns = (df.wchar_bytes_max - df.wchar_bytes_min) / window_ns
 
     # Then aggregate process individual process metrics.
     df = df.groupby(['timestamp', groupby]).agg(
         cpu_ktime_ms=('cpu_ktime_ms', px.sum),
         cpu_utime_ms=('cpu_utime_ms', px.sum),
-        read_mb_per_s=('read_mb_per_s', px.sum),
-        write_mb_per_s=('write_mb_per_s', px.sum),
-        rchar_mb_per_s=('rchar_mb_per_s', px.sum),
-        wchar_mb_per_s=('wchar_mb_per_s', px.sum),
-        rss_mb=('rss_mb', px.sum),
-        vsize_mb=('vsize_mb', px.sum),
+        read_bytes_per_ns=('read_bytes_per_ns', px.sum),
+        write_bytes_per_ns=('write_bytes_per_ns', px.sum),
+        rchar_bytes_per_ns=('rchar_bytes_per_ns', px.sum),
+        wchar_bytes_per_ns=('wchar_bytes_per_ns', px.sum),
+        rss_bytes=('rss_bytes', px.sum),
+        vsize_bytes=('vsize_bytes', px.sum),
     )
 
-    # Convert window_s into the same units as cpu time.
-    window_size_ms = window_s * 1.0E3
+    # Convert window_ns into the same units as cpu time.
+    window_size_ms = window_ns * 1.0E3
     # Finally, calculate total (kernel + user time)  percentage used over window.
     df.cpu_pct = (df.cpu_ktime_ms + df.cpu_utime_ms) / window_size_ms * 100
     df['time_'] = df['timestamp']
@@ -117,18 +108,15 @@ def network_stats(start_time: str, node: px.Node, groupby: str):
     df = px.DataFrame(table='network_stats', start_time=start_time)
     df = df[px.pod_id_to_node_name(df.pod_id) == node]
     df[groupby] = df.ctx[groupby]
-    df.timestamp = px.bin(df.time_, px.seconds(window_s))
-
-    df.rx_mb = df.rx_bytes / bytes_per_mb
-    df.tx_mb = df.tx_bytes / bytes_per_mb
+    df.timestamp = px.bin(df.time_, window_ns)
 
     # First calculate network usage by node over all windows.
     # Data is sharded by Pod in network_stats.
     df = df.groupby(['timestamp', 'pod_id', groupby]).agg(
-        rx_mb_end=('rx_mb', px.max),
-        rx_mb_start=('rx_mb', px.min),
-        tx_mb_end=('tx_mb', px.max),
-        tx_mb_start=('tx_mb', px.min),
+        rx_bytes_end=('rx_bytes', px.max),
+        rx_bytes_start=('rx_bytes', px.min),
+        tx_bytes_end=('tx_bytes', px.max),
+        tx_bytes_start=('tx_bytes', px.min),
         tx_errors_end=('tx_errors', px.max),
         tx_errors_start=('tx_errors', px.min),
         rx_errors_end=('rx_errors', px.max),
@@ -142,21 +130,21 @@ def network_stats(start_time: str, node: px.Node, groupby: str):
     # Calculate the network statistics rate over the window.
     # We subtract the counter value at the beginning ('_start')
     # from the value at the end ('_end').
-    df.rx_mb_per_s = (df.rx_mb_end - df.rx_mb_start) / window_s
-    df.tx_mb_per_s = (df.tx_mb_end - df.tx_mb_start) / window_s
-    df.rx_drops_per_s = (df.rx_drops_end - df.rx_drops_start) / window_s
-    df.tx_drops_per_s = (df.tx_drops_end - df.tx_drops_start) / window_s
-    df.rx_errors_per_s = (df.rx_errors_end - df.rx_errors_start) / window_s
-    df.tx_errors_per_s = (df.tx_errors_end - df.tx_errors_start) / window_s
+    df.rx_bytes_per_ns = (df.rx_bytes_end - df.rx_bytes_start) / window_ns
+    df.tx_bytes_per_ns = (df.tx_bytes_end - df.tx_bytes_start) / window_ns
+    df.rx_drops_per_ns = (df.rx_drops_end - df.rx_drops_start) / window_ns
+    df.tx_drops_per_ns = (df.tx_drops_end - df.tx_drops_start) / window_ns
+    df.rx_errors_per_ns = (df.rx_errors_end - df.rx_errors_start) / window_ns
+    df.tx_errors_per_ns = (df.tx_errors_end - df.tx_errors_start) / window_ns
 
     # Add up the network values per node.
     df = df.groupby(['timestamp', groupby]).agg(
-        rx_mb_per_s=('rx_mb_per_s', px.sum),
-        tx_mb_per_s=('tx_mb_per_s', px.sum),
-        rx_drop_per_s=('rx_drops_per_s', px.sum),
-        tx_drops_per_s=('tx_drops_per_s', px.sum),
-        rx_errors_per_s=('rx_errors_per_s', px.sum),
-        tx_errors_per_s=('tx_errors_per_s', px.sum),
+        rx_bytes_per_ns=('rx_bytes_per_ns', px.sum),
+        tx_bytes_per_ns=('tx_bytes_per_ns', px.sum),
+        rx_drop_per_ns=('rx_drops_per_ns', px.sum),
+        tx_drops_per_ns=('tx_drops_per_ns', px.sum),
+        rx_errors_per_ns=('rx_errors_per_ns', px.sum),
+        tx_errors_per_ns=('tx_errors_per_ns', px.sum),
     )
     df.groupby_col = df[groupby]
     df['time_'] = df['timestamp']

--- a/pxl_scripts/px/node/vis.json
+++ b/pxl_scripts/px/node/vis.json
@@ -88,7 +88,7 @@
       }
     },
     {
-      "name": "CPU %",
+      "name": "CPU Usage",
       "position": {
         "x": 8,
         "y": 0,
@@ -100,20 +100,20 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "cpu_pct",
+            "value": "cpu_usage",
             "mode": "MODE_LINE",
             "series": "groupby_col"
           }
         ],
         "title": "",
         "yAxis": {
-          "label": "CPU usage (%)"
+          "label": "CPU usage"
         },
         "xAxis": null
       }
     },
     {
-      "name": "Bytes read (MB/s)",
+      "name": "Bytes read",
       "position": {
         "x": 0,
         "y": 3,
@@ -125,20 +125,20 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "rchar_bytes_per_ns",
+            "value": "total_disk_read_throughput",
             "mode": "MODE_LINE",
             "series": "groupby_col"
           }
         ],
         "title": "",
         "yAxis": {
-          "label": "Bytes read (MB/s)"
+          "label": "Bytes read"
         },
         "xAxis": null
       }
     },
     {
-      "name": "Bytes written (MB/s)",
+      "name": "Bytes written",
       "position": {
         "x": 4,
         "y": 3,
@@ -150,14 +150,14 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "wchar_bytes_per_ns",
+            "value": "total_disk_write_throughput",
             "mode": "MODE_LINE",
             "series": "groupby_col"
           }
         ],
         "title": "",
         "yAxis": {
-          "label": "Bytes written (MB/s)"
+          "label": "Bytes written"
         },
         "xAxis": null
       }
@@ -182,7 +182,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "Sent Data (MB/s)"
+          "label": "Sent Data"
         },
         "xAxis": null
       }
@@ -207,13 +207,13 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "Received Data (MB/s)"
+          "label": "Received Data"
         },
         "xAxis": null
       }
     },
     {
-      "name": "Resident Set Size (MB)",
+      "name": "Resident Set Size",
       "position": {
         "x": 4,
         "y": 6,
@@ -225,7 +225,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "rss_bytes",
+            "value": "rss",
             "mode": "MODE_LINE",
             "series": "groupby_col",
             "stackBySeries": false
@@ -233,13 +233,13 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "Resident Memory Usage (mb)"
+          "label": "Resident Memory Usage"
         },
         "xAxis": null
       }
     },
     {
-      "name": "Virtual Memory Size (MB)",
+      "name": "Virtual Memory Size",
       "position": {
         "x": 8,
         "y": 6,
@@ -251,7 +251,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "vsize_bytes",
+            "value": "vsize",
             "mode": "MODE_LINE",
             "series": "groupby_col",
             "stackBySeries": false
@@ -259,7 +259,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "Virtual Memory Usage (MB)"
+          "label": "Virtual Memory Usage"
         },
         "xAxis": null
       }

--- a/pxl_scripts/px/node/vis.json
+++ b/pxl_scripts/px/node/vis.json
@@ -125,7 +125,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "rchar_mb_per_s",
+            "value": "rchar_bytes_per_ns",
             "mode": "MODE_LINE",
             "series": "groupby_col"
           }
@@ -150,7 +150,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "wchar_mb_per_s",
+            "value": "wchar_bytes_per_ns",
             "mode": "MODE_LINE",
             "series": "groupby_col"
           }
@@ -175,7 +175,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "tx_mb_per_s",
+            "value": "tx_bytes_per_ns",
             "mode": "MODE_LINE",
             "series": "groupby_col"
           }
@@ -200,7 +200,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "rx_mb_per_s",
+            "value": "rx_bytes_per_ns",
             "mode": "MODE_LINE",
             "series": "groupby_col"
           }
@@ -225,7 +225,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "rss_mb",
+            "value": "rss_bytes",
             "mode": "MODE_LINE",
             "series": "groupby_col",
             "stackBySeries": false
@@ -251,7 +251,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "vsize_mb",
+            "value": "vsize_bytes",
             "mode": "MODE_LINE",
             "series": "groupby_col",
             "stackBySeries": false

--- a/pxl_scripts/px/nodes/nodes.pxl
+++ b/pxl_scripts/px/nodes/nodes.pxl
@@ -15,6 +15,7 @@ ns_per_s = 1000 * ns_per_ms
 # Window size to use on time_ column for bucketing.
 window_ns = px.DurationNanos(10 * ns_per_s)
 
+
 def nodes(start_time: str):
     df = px.DataFrame(table='process_stats', start_time=start_time)
     df.node = df.ctx['node_name']
@@ -46,20 +47,16 @@ def process_stats(start_time: str):
     df.node = df.ctx['node_name']
     df.timestamp = px.bin(df.time_, window_ns)
 
-    # Convert nanoseconds to milliseconds.
-    df.cpu_utime_ms = df.cpu_utime_ns / 1.0E6
-    df.cpu_ktime_ms = df.cpu_ktime_ns / 1.0E6
-
     # First calculate CPU usage by process (UPID) in each k8s_object
     # over all windows.
     df = df.groupby(['node', 'upid', 'timestamp']).agg(
-        rss_bytes=('rss_bytes', px.mean),
-        vsize_bytes=('vsize_bytes', px.mean),
+        rss=('rss_bytes', px.mean),
+        vsize=('vsize_bytes', px.mean),
         # The fields below are counters, so we take the min and the max to subtract them.
-        cpu_utime_ms_max=('cpu_utime_ms', px.max),
-        cpu_utime_ms_min=('cpu_utime_ms', px.min),
-        cpu_ktime_ms_max=('cpu_ktime_ms', px.max),
-        cpu_ktime_ms_min=('cpu_ktime_ms', px.min),
+        cpu_utime_ns_max=('cpu_utime_ns', px.max),
+        cpu_utime_ns_min=('cpu_utime_ns', px.min),
+        cpu_ktime_ns_max=('cpu_ktime_ns', px.max),
+        cpu_ktime_ns_min=('cpu_ktime_ns', px.min),
         read_bytes_max=('read_bytes', px.max),
         read_bytes_min=('read_bytes', px.min),
         write_bytes_max=('write_bytes', px.max),
@@ -71,31 +68,29 @@ def process_stats(start_time: str):
     )
 
     # Next calculate cpu usage and memory stats per window.
-    df.cpu_utime_ms = df.cpu_utime_ms_max - df.cpu_utime_ms_min
-    df.cpu_ktime_ms = df.cpu_ktime_ms_max - df.cpu_ktime_ms_min
-    df.read_bytes_per_ns = (df.read_bytes_max - df.read_bytes_min) / window_ns
-    df.write_bytes_per_ns = (df.write_bytes_max - df.write_bytes_min) / window_ns
-    df.rchar_bytes_per_ns = (df.rchar_bytes_max - df.rchar_bytes_min) / window_ns
-    df.wchar_bytes_per_ns = (df.wchar_bytes_max - df.wchar_bytes_min) / window_ns
+    df.cpu_utime_ns = df.cpu_utime_ns_max - df.cpu_utime_ns_min
+    df.cpu_ktime_ns = df.cpu_ktime_ns_max - df.cpu_ktime_ns_min
+    df.actual_disk_read_throughput = (df.read_bytes_max - df.read_bytes_min) / window_ns
+    df.actual_disk_write_throughput = (df.write_bytes_max - df.write_bytes_min) / window_ns
+    df.total_disk_read_throughput = (df.rchar_bytes_max - df.rchar_bytes_min) / window_ns
+    df.total_disk_write_throughput = (df.wchar_bytes_max - df.wchar_bytes_min) / window_ns
 
     # Then aggregate process individual process metrics.
     df = df.groupby(['node', 'timestamp']).agg(
-        cpu_ktime_ms=('cpu_ktime_ms', px.sum),
-        cpu_utime_ms=('cpu_utime_ms', px.sum),
-        read_bytes_per_ns=('read_bytes_per_ns', px.sum),
-        write_bytes_per_ns=('write_bytes_per_ns', px.sum),
-        rchar_bytes_per_ns=('rchar_bytes_per_ns', px.sum),
-        wchar_bytes_per_ns=('wchar_bytes_per_ns', px.sum),
-        rss_bytes=('rss_bytes', px.sum),
-        vsize_bytes=('vsize_bytes', px.sum),
+        cpu_ktime_ns=('cpu_ktime_ns', px.sum),
+        cpu_utime_ns=('cpu_utime_ns', px.sum),
+        actual_disk_read_throughput=('actual_disk_read_throughput', px.sum),
+        actual_disk_write_throughput=('actual_disk_write_throughput', px.sum),
+        total_disk_read_throughput=('total_disk_read_throughput', px.sum),
+        total_disk_write_throughput=('total_disk_write_throughput', px.sum),
+        rss=('rss', px.sum),
+        vsize=('vsize', px.sum),
     )
 
-    # Convert window_ns into the same units as cpu time.
-    window_size_ms = window_ns * 1.0E3
     # Finally, calculate total (kernel + user time)  percentage used over window.
-    df.cpu_pct = (df.cpu_ktime_ms + df.cpu_utime_ms) / window_size_ms * 100
+    df.cpu_usage = px.Percent((df.cpu_ktime_ns + df.cpu_utime_ns) / window_ns)
     df['time_'] = df['timestamp']
-    return df.drop(['cpu_ktime_ms', 'cpu_utime_ms', 'timestamp'])
+    return df.drop(['cpu_ktime_ns', 'cpu_utime_ns', 'timestamp'])
 
 
 def network_stats(start_time: str):

--- a/pxl_scripts/px/nodes/nodes.pxl
+++ b/pxl_scripts/px/nodes/nodes.pxl
@@ -10,10 +10,10 @@ It also displays a list of pods that were on each node during the time window.
 '''
 import px
 
-
-window_s = 10
-bytes_per_mb = 1024.0 * 1024.0
-
+ns_per_ms = 1000 * 1000
+ns_per_s = 1000 * ns_per_ms
+# Window size to use on time_ column for bucketing.
+window_ns = px.DurationNanos(10 * ns_per_s)
 
 def nodes(start_time: str):
     df = px.DataFrame(table='process_stats', start_time=start_time)
@@ -44,15 +44,7 @@ def process_stats(start_time: str):
     '''
     df = px.DataFrame(table='process_stats', start_time=start_time)
     df.node = df.ctx['node_name']
-    df.timestamp = px.bin(df.time_, px.seconds(window_s))
-
-    # Convert bytes to MB.
-    df.vsize_mb = df.vsize_bytes / bytes_per_mb
-    df.rss_mb = df.rss_bytes / bytes_per_mb
-    df.read_mb = df.read_bytes / bytes_per_mb
-    df.write_mb = df.write_bytes / bytes_per_mb
-    df.rchar_mb = df.rchar_bytes / bytes_per_mb
-    df.wchar_mb = df.wchar_bytes / bytes_per_mb
+    df.timestamp = px.bin(df.time_, window_ns)
 
     # Convert nanoseconds to milliseconds.
     df.cpu_utime_ms = df.cpu_utime_ns / 1.0E6
@@ -61,46 +53,45 @@ def process_stats(start_time: str):
     # First calculate CPU usage by process (UPID) in each k8s_object
     # over all windows.
     df = df.groupby(['node', 'upid', 'timestamp']).agg(
-        rss_mb=('rss_mb', px.mean),
-        vsize_mb=('vsize_mb', px.mean),
+        rss_bytes=('rss_bytes', px.mean),
+        vsize_bytes=('vsize_bytes', px.mean),
         # The fields below are counters, so we take the min and the max to subtract them.
         cpu_utime_ms_max=('cpu_utime_ms', px.max),
         cpu_utime_ms_min=('cpu_utime_ms', px.min),
         cpu_ktime_ms_max=('cpu_ktime_ms', px.max),
         cpu_ktime_ms_min=('cpu_ktime_ms', px.min),
-        read_mb_max=('read_mb', px.max),
-        read_mb_min=('read_mb', px.min),
-        write_mb_max=('write_mb', px.max),
-        write_mb_min=('write_mb', px.min),
-        rchar_mb_max=('rchar_mb', px.max),
-        rchar_mb_min=('rchar_mb', px.min),
-        wchar_mb_max=('wchar_mb', px.max),
-        wchar_mb_min=('wchar_mb', px.min),
+        read_bytes_max=('read_bytes', px.max),
+        read_bytes_min=('read_bytes', px.min),
+        write_bytes_max=('write_bytes', px.max),
+        write_bytes_min=('write_bytes', px.min),
+        rchar_bytes_max=('rchar_bytes', px.max),
+        rchar_bytes_min=('rchar_bytes', px.min),
+        wchar_bytes_max=('wchar_bytes', px.max),
+        wchar_bytes_min=('wchar_bytes', px.min),
     )
 
-    window_size = 1.0 * window_s
     # Next calculate cpu usage and memory stats per window.
     df.cpu_utime_ms = df.cpu_utime_ms_max - df.cpu_utime_ms_min
     df.cpu_ktime_ms = df.cpu_ktime_ms_max - df.cpu_ktime_ms_min
-    df.read_mb_per_s = (df.read_mb_max - df.read_mb_min) / window_size
-    df.write_mb_per_s = (df.write_mb_max - df.write_mb_min) / window_size
-    df.rchar_mb_per_s = (df.rchar_mb_max - df.rchar_mb_min) / window_size
-    df.wchar_mb_per_s = (df.wchar_mb_max - df.wchar_mb_min) / window_size
+    df.read_bytes_per_ns = (df.read_bytes_max - df.read_bytes_min) / window_ns
+    df.write_bytes_per_ns = (df.write_bytes_max - df.write_bytes_min) / window_ns
+    df.rchar_bytes_per_ns = (df.rchar_bytes_max - df.rchar_bytes_min) / window_ns
+    df.wchar_bytes_per_ns = (df.wchar_bytes_max - df.wchar_bytes_min) / window_ns
 
     # Then aggregate process individual process metrics.
     df = df.groupby(['node', 'timestamp']).agg(
         cpu_ktime_ms=('cpu_ktime_ms', px.sum),
         cpu_utime_ms=('cpu_utime_ms', px.sum),
-        read_mb_per_s=('read_mb_per_s', px.sum),
-        write_mb_per_s=('write_mb_per_s', px.sum),
-        rchar_mb_per_s=('rchar_mb_per_s', px.sum),
-        wchar_mb_per_s=('wchar_mb_per_s', px.sum),
-        rss_mb=('rss_mb', px.sum),
-        vsize_mb=('vsize_mb', px.sum),
+        read_bytes_per_ns=('read_bytes_per_ns', px.sum),
+        write_bytes_per_ns=('write_bytes_per_ns', px.sum),
+        rchar_bytes_per_ns=('rchar_bytes_per_ns', px.sum),
+        wchar_bytes_per_ns=('wchar_bytes_per_ns', px.sum),
+        rss_bytes=('rss_bytes', px.sum),
+        vsize_bytes=('vsize_bytes', px.sum),
     )
 
-    # Convert window_s into the same units as cpu time.
-    window_size_ms = window_s * 1.0E3
+    # Convert window_ns into the same units as cpu time.
+    window_size_ms = window_ns * 1.0E3
     # Finally, calculate total (kernel + user time)  percentage used over window.
     df.cpu_pct = (df.cpu_ktime_ms + df.cpu_utime_ms) / window_size_ms * 100
     df['time_'] = df['timestamp']
@@ -115,18 +106,15 @@ def network_stats(start_time: str):
     '''
     df = px.DataFrame(table='network_stats', start_time=start_time)
     df.node = px.pod_id_to_node_name(df.pod_id)
-    df.timestamp = px.bin(df.time_, px.seconds(window_s))
-
-    df.rx_mb = df.rx_bytes / bytes_per_mb
-    df.tx_mb = df.tx_bytes / bytes_per_mb
+    df.timestamp = px.bin(df.time_, window_ns)
 
     # First calculate network usage by node over all windows.
     # Data is sharded by Pod in network_stats.
     df = df.groupby(['node', 'pod_id', 'timestamp']).agg(
-        rx_mb_end=('rx_mb', px.max),
-        rx_mb_start=('rx_mb', px.min),
-        tx_mb_end=('tx_mb', px.max),
-        tx_mb_start=('tx_mb', px.min),
+        rx_bytes_end=('rx_bytes', px.max),
+        rx_bytes_start=('rx_bytes', px.min),
+        tx_bytes_end=('tx_bytes', px.max),
+        tx_bytes_start=('tx_bytes', px.min),
         tx_errors_end=('tx_errors', px.max),
         tx_errors_start=('tx_errors', px.min),
         rx_errors_end=('rx_errors', px.max),
@@ -140,21 +128,21 @@ def network_stats(start_time: str):
     # Calculate the network statistics rate over the window.
     # We subtract the counter value at the beginning ('_start')
     # from the value at the end ('_end').
-    df.rx_mb_per_s = (df.rx_mb_end - df.rx_mb_start) / window_s
-    df.tx_mb_per_s = (df.tx_mb_end - df.tx_mb_start) / window_s
-    df.rx_drops_per_s = (df.rx_drops_end - df.rx_drops_start) / window_s
-    df.tx_drops_per_s = (df.tx_drops_end - df.tx_drops_start) / window_s
-    df.rx_errors_per_s = (df.rx_errors_end - df.rx_errors_start) / window_s
-    df.tx_errors_per_s = (df.tx_errors_end - df.tx_errors_start) / window_s
+    df.rx_bytes_per_ns = (df.rx_bytes_end - df.rx_bytes_start) / window_ns
+    df.tx_bytes_per_ns = (df.tx_bytes_end - df.tx_bytes_start) / window_ns
+    df.rx_drops_per_ns = (df.rx_drops_end - df.rx_drops_start) / window_ns
+    df.tx_drops_per_ns = (df.tx_drops_end - df.tx_drops_start) / window_ns
+    df.rx_errors_per_ns = (df.rx_errors_end - df.rx_errors_start) / window_ns
+    df.tx_errors_per_ns = (df.tx_errors_end - df.tx_errors_start) / window_ns
 
     # Add up the network values per node.
     df = df.groupby(['node', 'timestamp']).agg(
-        rx_mb_per_s=('rx_mb_per_s', px.sum),
-        tx_mb_per_s=('tx_mb_per_s', px.sum),
-        rx_drop_per_s=('rx_drops_per_s', px.sum),
-        tx_drops_per_s=('tx_drops_per_s', px.sum),
-        rx_errors_per_s=('rx_errors_per_s', px.sum),
-        tx_errors_per_s=('tx_errors_per_s', px.sum),
+        rx_bytes_per_ns=('rx_bytes_per_ns', px.sum),
+        tx_bytes_per_ns=('tx_bytes_per_ns', px.sum),
+        rx_drop_per_ns=('rx_drops_per_ns', px.sum),
+        tx_drops_per_ns=('tx_drops_per_ns', px.sum),
+        rx_errors_per_ns=('rx_errors_per_ns', px.sum),
+        tx_errors_per_ns=('tx_errors_per_ns', px.sum),
     )
     df['time_'] = df['timestamp']
     return df

--- a/pxl_scripts/px/nodes/vis.json
+++ b/pxl_scripts/px/nodes/vis.json
@@ -56,7 +56,7 @@
       }
     },
     {
-      "name": "CPU %",
+      "name": "CPU Usage",
       "position": {
         "x": 4,
         "y": 0,
@@ -68,7 +68,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "cpu_pct",
+            "value": "cpu_usage",
             "mode": "MODE_LINE",
             "series": "node",
             "stackBySeries": false
@@ -76,7 +76,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "CPU usage (%)"
+          "label": "CPU usage"
         },
         "xAxis": null
       }
@@ -102,7 +102,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "Sent Data (MB/s)"
+          "label": "Sent Data"
         },
         "xAxis": null
       }
@@ -128,13 +128,13 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "Received Data (MB/s)"
+          "label": "Received Data"
         },
         "xAxis": null
       }
     },
     {
-      "name": "Bytes read (MB/s)",
+      "name": "Bytes read",
       "position": {
         "x": 4,
         "y": 3,
@@ -146,7 +146,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "rchar_bytes_per_ns",
+            "value": "total_disk_read_throughput",
             "mode": "MODE_LINE",
             "series": "node",
             "stackBySeries": false
@@ -154,13 +154,13 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "Bytes read (MB/s)"
+          "label": "Bytes read"
         },
         "xAxis": null
       }
     },
     {
-      "name": "Bytes written (MB/s)",
+      "name": "Bytes written",
       "position": {
         "x": 8,
         "y": 3,
@@ -172,7 +172,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "wchar_bytes_per_ns",
+            "value": "total_disk_write_throughput",
             "mode": "MODE_LINE",
             "series": "node",
             "stackBySeries": false
@@ -180,7 +180,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "Bytes written (MB/s)"
+          "label": "Bytes written"
         },
         "xAxis": null
       }

--- a/pxl_scripts/px/nodes/vis.json
+++ b/pxl_scripts/px/nodes/vis.json
@@ -94,7 +94,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "tx_mb_per_s",
+            "value": "tx_bytes_per_ns",
             "mode": "MODE_LINE",
             "series": "node",
             "stackBySeries": false
@@ -120,7 +120,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "rx_mb_per_s",
+            "value": "rx_bytes_per_ns",
             "mode": "MODE_LINE",
             "series": "node",
             "stackBySeries": false
@@ -146,7 +146,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "rchar_mb_per_s",
+            "value": "rchar_bytes_per_ns",
             "mode": "MODE_LINE",
             "series": "node",
             "stackBySeries": false
@@ -172,7 +172,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "wchar_mb_per_s",
+            "value": "wchar_bytes_per_ns",
             "mode": "MODE_LINE",
             "series": "node",
             "stackBySeries": false

--- a/pxl_scripts/px/pid_memory_usage/usage.pxl
+++ b/pxl_scripts/px/pid_memory_usage/usage.pxl
@@ -8,15 +8,12 @@ import px
 #
 t1 = px.DataFrame(table='process_stats', start_time='-30s')
 
-bytes_per_mb = 1024.0 * 1024.0
-t1.vsize_mb = t1.vsize_bytes / bytes_per_mb
-t1.rss_bytes_mb = t1.rss_bytes / bytes_per_mb
 t1.timestamp = px.bin(t1.time_, px.seconds(10))
 t1.cmdline = px.upid_to_cmdline(t1.upid)
 
 aggop = t1.groupby(['upid', 'timestamp', 'cmdline']).agg(
-    vsize_mb=('vsize_mb', px.mean),
-    rss_bytes_mb=('rss_bytes_mb', px.mean),
+    vsize_bytes=('vsize_bytes', px.mean),
+    rss_bytes_bytes=('rss_bytes_bytes', px.mean),
 )
 
 # Format column names.
@@ -27,8 +24,8 @@ aggop['Process Name'] = aggop.cmdline
 # Uncomment and replace number to filter on a specific pid.
 # aggop = aggop[aggop.pid == 4862]
 
-aggop['Virtual Memory (mb)'] = aggop.vsize_mb
-aggop['Average Memory (mb)'] = aggop.rss_bytes_mb
+aggop['Virtual Memory (mb)'] = aggop.vsize_bytes
+aggop['Average Memory (mb)'] = aggop.rss_bytes_bytes
 keep_columns = aggop[[
     'pid',
     'Process Name',

--- a/pxl_scripts/px/pid_memory_usage/usage.pxl
+++ b/pxl_scripts/px/pid_memory_usage/usage.pxl
@@ -12,8 +12,8 @@ t1.timestamp = px.bin(t1.time_, px.seconds(10))
 t1.cmdline = px.upid_to_cmdline(t1.upid)
 
 aggop = t1.groupby(['upid', 'timestamp', 'cmdline']).agg(
-    vsize_bytes=('vsize_bytes', px.mean),
-    rss_bytes_bytes=('rss_bytes_bytes', px.mean),
+    vsize=('vsize_bytes', px.mean),
+    rss=('rss_bytes', px.mean),
 )
 
 # Format column names.
@@ -24,15 +24,15 @@ aggop['Process Name'] = aggop.cmdline
 # Uncomment and replace number to filter on a specific pid.
 # aggop = aggop[aggop.pid == 4862]
 
-aggop['Virtual Memory (mb)'] = aggop.vsize_bytes
-aggop['Average Memory (mb)'] = aggop.rss_bytes_bytes
+aggop['Virtual Memory'] = aggop.vsize
+aggop['Average Memory'] = aggop.rss
 keep_columns = aggop[[
     'pid',
     'Process Name',
     'asid',
     'timestamp',
-    'Virtual Memory (mb)',
-    'Average Memory (mb)'
+    'Virtual Memory',
+    'Average Memory'
 ]]
 
 px.display(keep_columns)

--- a/pxl_scripts/px/pixie_quality_metrics/pixie_quality_metrics.pxl
+++ b/pxl_scripts/px/pixie_quality_metrics/pixie_quality_metrics.pxl
@@ -3,12 +3,13 @@
 
 import px
 
+ns_per_ms = 1000 * 1000
+
 
 def events(t1, latency_col):
-    t1.latency_ms = t1[latency_col] / 1.0E6
-    t1.latency_huge = t1.latency_ms > 10.0
-    t1.negative_latencies = t1.latency_ms < 0.0
-    return t1.groupby(['latency_huge', 'negative_latencies']).agg(count=('latency_ms', px.count))
+    t1.latency_huge = t1[latency_col] > (10 * ns_per_ms)
+    t1.negative_latencies = t1[latency_col] < 0
+    return t1.groupby(['latency_huge', 'negative_latencies']).agg(count=(latency_col, px.count))
 
 
 t1 = px.DataFrame(table='http_events', start_time='-300s')

--- a/pxl_scripts/px/pod/pod.pxl
+++ b/pxl_scripts/px/pod/pod.pxl
@@ -11,9 +11,10 @@ Overview of a specific Pod monitored by Pixie with its high level application me
 import px
 
 
-bytes_per_mb = 1024.0 * 1024.0
-# Window size for computing timeseries
-window_s = 10
+ns_per_ms = 1000 * 1000
+ns_per_s = 1000 * ns_per_ms
+# Window size to use on time_ column for bucketing.
+window_ns = px.DurationNanos(10 * ns_per_s)
 # Flag to filter out requests that come from an unresolvable IP.
 filter_unresolved_inbound = True
 # Flag to filter out health checks from the data.
@@ -65,16 +66,8 @@ def resource_timeseries(start_time: str, pod: px.Pod):
     '''
     df = px.DataFrame(table='process_stats', start_time=start_time)
     df = df[df.ctx['pod'] == pod]
-    df.timestamp = px.bin(df.time_, px.seconds(window_s))
+    df.timestamp = px.bin(df.time_, window_ns)
     df.container = df.ctx['container_name']
-
-    # Convert bytes to MB.
-    df.vsize_mb = df.vsize_bytes / bytes_per_mb
-    df.rss_mb = df.rss_bytes / bytes_per_mb
-    df.read_mb = df.read_bytes / bytes_per_mb
-    df.write_mb = df.write_bytes / bytes_per_mb
-    df.rchar_mb = df.rchar_bytes / bytes_per_mb
-    df.wchar_mb = df.wchar_bytes / bytes_per_mb
 
     # Convert nanoseconds to milliseconds.
     df.cpu_utime_ms = df.cpu_utime_ns / 1.0E6
@@ -83,46 +76,45 @@ def resource_timeseries(start_time: str, pod: px.Pod):
     # First calculate CPU usage by process (UPID) in each k8s_object
     # over all windows.
     df = df.groupby(['upid', 'container', 'timestamp']).agg(
-        rss_mb=('rss_mb', px.mean),
-        vsize_mb=('vsize_mb', px.mean),
+        rss_bytes=('rss_bytes', px.mean),
+        vsize_bytes=('vsize_bytes', px.mean),
         # The fields below are counters, so we take the min and the max to subtract them.
         cpu_utime_ms_max=('cpu_utime_ms', px.max),
         cpu_utime_ms_min=('cpu_utime_ms', px.min),
         cpu_ktime_ms_max=('cpu_ktime_ms', px.max),
         cpu_ktime_ms_min=('cpu_ktime_ms', px.min),
-        read_mb_max=('read_mb', px.max),
-        read_mb_min=('read_mb', px.min),
-        write_mb_max=('write_mb', px.max),
-        write_mb_min=('write_mb', px.min),
-        rchar_mb_max=('rchar_mb', px.max),
-        rchar_mb_min=('rchar_mb', px.min),
-        wchar_mb_max=('wchar_mb', px.max),
-        wchar_mb_min=('wchar_mb', px.min),
+        read_bytes_max=('read_bytes', px.max),
+        read_bytes_min=('read_bytes', px.min),
+        write_bytes_max=('write_bytes', px.max),
+        write_bytes_min=('write_bytes', px.min),
+        rchar_bytes_max=('rchar_bytes', px.max),
+        rchar_bytes_min=('rchar_bytes', px.min),
+        wchar_bytes_max=('wchar_bytes', px.max),
+        wchar_bytes_min=('wchar_bytes', px.min),
     )
 
-    window_size = 1.0 * window_s
     # Next calculate cpu usage and memory stats per window.
     df.cpu_utime_ms = df.cpu_utime_ms_max - df.cpu_utime_ms_min
     df.cpu_ktime_ms = df.cpu_ktime_ms_max - df.cpu_ktime_ms_min
-    df.read_mb_per_s = (df.read_mb_max - df.read_mb_min) / window_size
-    df.write_mb_per_s = (df.write_mb_max - df.write_mb_min) / window_size
-    df.rchar_mb_per_s = (df.rchar_mb_max - df.rchar_mb_min) / window_size
-    df.wchar_mb_per_s = (df.wchar_mb_max - df.wchar_mb_min) / window_size
+    df.read_bytes_per_ns = (df.read_bytes_max - df.read_bytes_min) / window_ns
+    df.write_bytes_per_ns = (df.write_bytes_max - df.write_bytes_min) / window_ns
+    df.rchar_bytes_per_ns = (df.rchar_bytes_max - df.rchar_bytes_min) / window_ns
+    df.wchar_bytes_per_ns = (df.wchar_bytes_max - df.wchar_bytes_min) / window_ns
 
     # Then aggregate process individual process metrics.
     df = df.groupby(['timestamp', 'container']).agg(
         cpu_ktime_ms=('cpu_ktime_ms', px.sum),
         cpu_utime_ms=('cpu_utime_ms', px.sum),
-        read_mb_per_s=('read_mb_per_s', px.sum),
-        write_mb_per_s=('write_mb_per_s', px.sum),
-        rchar_mb_per_s=('rchar_mb_per_s', px.sum),
-        wchar_mb_per_s=('wchar_mb_per_s', px.sum),
-        rss_mb=('rss_mb', px.sum),
-        vsize_mb=('vsize_mb', px.sum),
+        read_bytes_per_ns=('read_bytes_per_ns', px.sum),
+        write_bytes_per_ns=('write_bytes_per_ns', px.sum),
+        rchar_bytes_per_ns=('rchar_bytes_per_ns', px.sum),
+        wchar_bytes_per_ns=('wchar_bytes_per_ns', px.sum),
+        rss_bytes=('rss_bytes', px.sum),
+        vsize_bytes=('vsize_bytes', px.sum),
     )
 
-    # Convert window_s into the same units as cpu time.
-    window_size_ms = window_s * 1.0E3
+    # Convert window_ns into the same units as cpu time.
+    window_size_ms = window_ns * 1.0E3
     # Finally, calculate total (kernel + user time)  percentage used over window.
     df.cpu_pct = (df.cpu_ktime_ms + df.cpu_utime_ms) / window_size_ms * 100
     df['time_'] = df['timestamp']
@@ -138,18 +130,15 @@ def network_timeseries(start_time: str, pod: px.Pod):
     '''
     df = px.DataFrame(table='network_stats', start_time=start_time)
     df = df[df.ctx['pod'] == pod]
-    df.timestamp = px.bin(df.time_, px.seconds(window_s))
-
-    df.rx_mb = df.rx_bytes / bytes_per_mb
-    df.tx_mb = df.tx_bytes / bytes_per_mb
+    df.timestamp = px.bin(df.time_, window_ns)
 
     # First calculate network usage by node over all windows.
     # Data is sharded by Pod in network_stats.
     df = df.groupby(['timestamp', 'pod_id']).agg(
-        rx_mb_end=('rx_mb', px.max),
-        rx_mb_start=('rx_mb', px.min),
-        tx_mb_end=('tx_mb', px.max),
-        tx_mb_start=('tx_mb', px.min),
+        rx_bytes_end=('rx_bytes', px.max),
+        rx_bytes_start=('rx_bytes', px.min),
+        tx_bytes_end=('tx_bytes', px.max),
+        tx_bytes_start=('tx_bytes', px.min),
         tx_errors_end=('tx_errors', px.max),
         tx_errors_start=('tx_errors', px.min),
         rx_errors_end=('rx_errors', px.max),
@@ -163,21 +152,21 @@ def network_timeseries(start_time: str, pod: px.Pod):
     # Calculate the network statistics rate over the window.
     # We subtract the counter value at the beginning ('_start')
     # from the value at the end ('_end').
-    df.rx_mb_per_s = (df.rx_mb_end - df.rx_mb_start) / window_s
-    df.tx_mb_per_s = (df.tx_mb_end - df.tx_mb_start) / window_s
-    df.rx_drops_per_s = (df.rx_drops_end - df.rx_drops_start) / window_s
-    df.tx_drops_per_s = (df.tx_drops_end - df.tx_drops_start) / window_s
-    df.rx_errors_per_s = (df.rx_errors_end - df.rx_errors_start) / window_s
-    df.tx_errors_per_s = (df.tx_errors_end - df.tx_errors_start) / window_s
+    df.rx_bytes_per_ns = (df.rx_bytes_end - df.rx_bytes_start) / window_ns
+    df.tx_bytes_per_ns = (df.tx_bytes_end - df.tx_bytes_start) / window_ns
+    df.rx_drops_per_ns = (df.rx_drops_end - df.rx_drops_start) / window_ns
+    df.tx_drops_per_ns = (df.tx_drops_end - df.tx_drops_start) / window_ns
+    df.rx_errors_per_ns = (df.rx_errors_end - df.rx_errors_start) / window_ns
+    df.tx_errors_per_ns = (df.tx_errors_end - df.tx_errors_start) / window_ns
 
     # Add up the network values per node.
     df = df.groupby(['timestamp']).agg(
-        rx_mb_per_s=('rx_mb_per_s', px.sum),
-        tx_mb_per_s=('tx_mb_per_s', px.sum),
-        rx_drop_per_s=('rx_drops_per_s', px.sum),
-        tx_drops_per_s=('tx_drops_per_s', px.sum),
-        rx_errors_per_s=('rx_errors_per_s', px.sum),
-        tx_errors_per_s=('tx_errors_per_s', px.sum),
+        rx_bytes_per_ns=('rx_bytes_per_ns', px.sum),
+        tx_bytes_per_ns=('tx_bytes_per_ns', px.sum),
+        rx_drop_per_ns=('rx_drops_per_ns', px.sum),
+        tx_drops_per_ns=('tx_drops_per_ns', px.sum),
+        rx_errors_per_ns=('rx_errors_per_ns', px.sum),
+        tx_errors_per_ns=('tx_errors_per_ns', px.sum),
     )
     df['time_'] = df['timestamp']
     return df
@@ -195,7 +184,7 @@ def inbound_latency_timeseries(start_time: str, pod: px.Pod):
     df = df[df.pod == pod]
 
     df = df.groupby(['timestamp']).agg(
-        latency_quantiles=('latency_ms', px.quantiles)
+        latency_quantiles=('latency_ns', px.quantiles)
     )
 
     # Format the result of LET aggregates into proper scalar formats and
@@ -222,18 +211,17 @@ def inbound_request_timeseries_by_container(start_time: str, pod: px.Pod):
 
     df = df.groupby(['timestamp', 'container']).agg(
         error_rate_per_window=('failure', px.mean),
-        throughput_total=('latency_ms', px.count)
+        throughput_total=('latency_ns', px.count)
     )
 
     # Format the result of LET aggregates into proper scalar formats and
     # time series.
-    window_size = window_s * 1.0
-    df.requests_per_s = df.throughput_total / window_size
-    df.errors_per_s = df.error_rate_per_window * df.requests_per_s
-    df.error_rate_pct = df.error_rate_per_window * 100
+    df.requests_per_ns = df.throughput_total / window_ns
+    df.errors_per_ns = df.error_rate_per_window * df.requests_per_ns
+    df.error_rate_pct = px.Percent(df.error_rate_per_window)
     df.time_ = df.timestamp
 
-    return df[['time_', 'container', 'requests_per_s', 'errors_per_s', 'error_rate_pct']]
+    return df[['time_', 'container', 'requests_per_ns', 'errors_per_ns', 'error_rate_pct']]
 
 
 def inbound_let_summary(start_time: str, pod: px.Pod):
@@ -247,11 +235,11 @@ def inbound_let_summary(start_time: str, pod: px.Pod):
     df = df[df.pod == pod]
 
     quantiles_agg = df.groupby(['pod', 'remote_addr']).agg(
-        latency_ms=('latency_ms', px.quantiles),
-        total_request_count=('latency_ms', px.count)
+        latency_ns=('latency_ns', px.quantiles),
+        total_request_count=('latency_ns', px.count)
     )
 
-    quantiles_table = quantiles_agg[['pod', 'remote_addr', 'latency_ms',
+    quantiles_table = quantiles_agg[['pod', 'remote_addr', 'latency_ns',
                                      'total_request_count']]
 
     range_agg = df.groupby(['pod', 'remote_addr', 'timestamp']).agg(
@@ -270,14 +258,14 @@ def inbound_let_summary(start_time: str, pod: px.Pod):
                                          right_on=['pod', 'remote_addr'],
                                          suffixes=['', '_x'])
 
-    joined_table.error_rate_pct = 100 * joined_table.error_rate
-    joined_table.requests_per_s = joined_table.requests_per_window / (1.0 * window_s)
+    joined_table.error_rate_pct = px.Percent(joined_table.error_rate)
+    joined_table.requests_per_ns = joined_table.requests_per_window / window_ns
 
     joined_table.responder = df.pod
     joined_table.requestor = px.pod_id_to_pod_name(px.ip_to_pod_id(df.remote_addr))
 
-    return joined_table[['requestor', 'remote_addr', 'latency_ms',
-                         'error_rate_pct', 'requests_per_s']]
+    return joined_table[['requestor', 'remote_addr', 'latency_ns',
+                         'error_rate_pct', 'requests_per_ns']]
 
 
 def let_helper(start_time: str):
@@ -290,9 +278,9 @@ def let_helper(start_time: str):
     '''
     df = px.DataFrame(table='http_events', start_time=start_time)
     df.pod = df.ctx['pod']
-    df.latency_ms = df.http_resp_latency_ns / 1.0E6
-    df = df[df['latency_ms'] < 10000.0]
-    df.timestamp = px.bin(df.time_, px.seconds(window_s))
+    df.latency_ns = df.http_resp_latency_ns
+    df = df[df['latency_ns'] < (10000 * 1000000)]
+    df.timestamp = px.bin(df.time_, window_ns)
 
     df.resp_size = px.length(df.http_resp_body)
     df.failure = df.http_resp_status >= 400

--- a/pxl_scripts/px/pod/pod.pxl
+++ b/pxl_scripts/px/pod/pod.pxl
@@ -69,20 +69,16 @@ def resource_timeseries(start_time: str, pod: px.Pod):
     df.timestamp = px.bin(df.time_, window_ns)
     df.container = df.ctx['container_name']
 
-    # Convert nanoseconds to milliseconds.
-    df.cpu_utime_ms = df.cpu_utime_ns / 1.0E6
-    df.cpu_ktime_ms = df.cpu_ktime_ns / 1.0E6
-
     # First calculate CPU usage by process (UPID) in each k8s_object
     # over all windows.
     df = df.groupby(['upid', 'container', 'timestamp']).agg(
-        rss_bytes=('rss_bytes', px.mean),
-        vsize_bytes=('vsize_bytes', px.mean),
+        rss=('rss_bytes', px.mean),
+        vsize=('vsize_bytes', px.mean),
         # The fields below are counters, so we take the min and the max to subtract them.
-        cpu_utime_ms_max=('cpu_utime_ms', px.max),
-        cpu_utime_ms_min=('cpu_utime_ms', px.min),
-        cpu_ktime_ms_max=('cpu_ktime_ms', px.max),
-        cpu_ktime_ms_min=('cpu_ktime_ms', px.min),
+        cpu_utime_ns_max=('cpu_utime_ns', px.max),
+        cpu_utime_ns_min=('cpu_utime_ns', px.min),
+        cpu_ktime_ns_max=('cpu_ktime_ns', px.max),
+        cpu_ktime_ns_min=('cpu_ktime_ns', px.min),
         read_bytes_max=('read_bytes', px.max),
         read_bytes_min=('read_bytes', px.min),
         write_bytes_max=('write_bytes', px.max),
@@ -94,31 +90,29 @@ def resource_timeseries(start_time: str, pod: px.Pod):
     )
 
     # Next calculate cpu usage and memory stats per window.
-    df.cpu_utime_ms = df.cpu_utime_ms_max - df.cpu_utime_ms_min
-    df.cpu_ktime_ms = df.cpu_ktime_ms_max - df.cpu_ktime_ms_min
-    df.read_bytes_per_ns = (df.read_bytes_max - df.read_bytes_min) / window_ns
-    df.write_bytes_per_ns = (df.write_bytes_max - df.write_bytes_min) / window_ns
-    df.rchar_bytes_per_ns = (df.rchar_bytes_max - df.rchar_bytes_min) / window_ns
-    df.wchar_bytes_per_ns = (df.wchar_bytes_max - df.wchar_bytes_min) / window_ns
+    df.cpu_utime_ns = df.cpu_utime_ns_max - df.cpu_utime_ns_min
+    df.cpu_ktime_ns = df.cpu_ktime_ns_max - df.cpu_ktime_ns_min
+    df.actual_disk_read_throughput = (df.read_bytes_max - df.read_bytes_min) / window_ns
+    df.actual_disk_write_throughput = (df.write_bytes_max - df.write_bytes_min) / window_ns
+    df.total_disk_read_throughput = (df.rchar_bytes_max - df.rchar_bytes_min) / window_ns
+    df.total_disk_write_throughput = (df.wchar_bytes_max - df.wchar_bytes_min) / window_ns
 
     # Then aggregate process individual process metrics.
     df = df.groupby(['timestamp', 'container']).agg(
-        cpu_ktime_ms=('cpu_ktime_ms', px.sum),
-        cpu_utime_ms=('cpu_utime_ms', px.sum),
-        read_bytes_per_ns=('read_bytes_per_ns', px.sum),
-        write_bytes_per_ns=('write_bytes_per_ns', px.sum),
-        rchar_bytes_per_ns=('rchar_bytes_per_ns', px.sum),
-        wchar_bytes_per_ns=('wchar_bytes_per_ns', px.sum),
-        rss_bytes=('rss_bytes', px.sum),
-        vsize_bytes=('vsize_bytes', px.sum),
+        cpu_ktime_ns=('cpu_ktime_ns', px.sum),
+        cpu_utime_ns=('cpu_utime_ns', px.sum),
+        actual_disk_read_throughput=('actual_disk_read_throughput', px.sum),
+        actual_disk_write_throughput=('actual_disk_write_throughput', px.sum),
+        total_disk_read_throughput=('total_disk_read_throughput', px.sum),
+        total_disk_write_throughput=('total_disk_write_throughput', px.sum),
+        rss=('rss', px.sum),
+        vsize=('vsize', px.sum),
     )
 
-    # Convert window_ns into the same units as cpu time.
-    window_size_ms = window_ns * 1.0E3
     # Finally, calculate total (kernel + user time)  percentage used over window.
-    df.cpu_pct = (df.cpu_ktime_ms + df.cpu_utime_ms) / window_size_ms * 100
+    df.cpu_usage = px.Percent((df.cpu_ktime_ns + df.cpu_utime_ns) / window_ns)
     df['time_'] = df['timestamp']
-    return df.drop(['cpu_ktime_ms', 'cpu_utime_ms', 'timestamp'])
+    return df.drop(['cpu_ktime_ns', 'cpu_utime_ns', 'timestamp'])
 
 
 def network_timeseries(start_time: str, pod: px.Pod):
@@ -184,14 +178,14 @@ def inbound_latency_timeseries(start_time: str, pod: px.Pod):
     df = df[df.pod == pod]
 
     df = df.groupby(['timestamp']).agg(
-        latency_quantiles=('latency_ns', px.quantiles)
+        latency_quantiles=('latency', px.quantiles)
     )
 
     # Format the result of LET aggregates into proper scalar formats and
     # time series.
-    df.latency_p50 = px.pluck_float64(df.latency_quantiles, 'p50')
-    df.latency_p90 = px.pluck_float64(df.latency_quantiles, 'p90')
-    df.latency_p99 = px.pluck_float64(df.latency_quantiles, 'p99')
+    df.latency_p50 = px.DurationNanos(px.floor(px.pluck_float64(df.latency_quantiles, 'p50')))
+    df.latency_p90 = px.DurationNanos(px.floor(px.pluck_float64(df.latency_quantiles, 'p90')))
+    df.latency_p99 = px.DurationNanos(px.floor(px.pluck_float64(df.latency_quantiles, 'p99')))
     df.time_ = df.timestamp
     return df[['time_', 'latency_p50', 'latency_p90', 'latency_p99']]
 
@@ -211,17 +205,17 @@ def inbound_request_timeseries_by_container(start_time: str, pod: px.Pod):
 
     df = df.groupby(['timestamp', 'container']).agg(
         error_rate_per_window=('failure', px.mean),
-        throughput_total=('latency_ns', px.count)
+        throughput_total=('latency', px.count)
     )
 
     # Format the result of LET aggregates into proper scalar formats and
     # time series.
-    df.requests_per_ns = df.throughput_total / window_ns
-    df.errors_per_ns = df.error_rate_per_window * df.requests_per_ns
-    df.error_rate_pct = px.Percent(df.error_rate_per_window)
+    df.request_throughput = df.throughput_total / window_ns
+    df.errors_per_ns = df.error_rate_per_window * df.request_throughput / px.DurationNanos(1)
+    df.error_rate = px.Percent(df.error_rate_per_window)
     df.time_ = df.timestamp
 
-    return df[['time_', 'container', 'requests_per_ns', 'errors_per_ns', 'error_rate_pct']]
+    return df[['time_', 'container', 'request_throughput', 'errors_per_ns', 'error_rate']]
 
 
 def inbound_let_summary(start_time: str, pod: px.Pod):
@@ -235,11 +229,11 @@ def inbound_let_summary(start_time: str, pod: px.Pod):
     df = df[df.pod == pod]
 
     quantiles_agg = df.groupby(['pod', 'remote_addr']).agg(
-        latency_ns=('latency_ns', px.quantiles),
-        total_request_count=('latency_ns', px.count)
+        latency=('latency', px.quantiles),
+        total_request_count=('latency', px.count)
     )
 
-    quantiles_table = quantiles_agg[['pod', 'remote_addr', 'latency_ns',
+    quantiles_table = quantiles_agg[['pod', 'remote_addr', 'latency',
                                      'total_request_count']]
 
     range_agg = df.groupby(['pod', 'remote_addr', 'timestamp']).agg(
@@ -258,14 +252,14 @@ def inbound_let_summary(start_time: str, pod: px.Pod):
                                          right_on=['pod', 'remote_addr'],
                                          suffixes=['', '_x'])
 
-    joined_table.error_rate_pct = px.Percent(joined_table.error_rate)
-    joined_table.requests_per_ns = joined_table.requests_per_window / window_ns
+    joined_table.error_rate = px.Percent(joined_table.error_rate)
+    joined_table.request_throughput = joined_table.requests_per_window / window_ns
 
     joined_table.responder = df.pod
     joined_table.requestor = px.pod_id_to_pod_name(px.ip_to_pod_id(df.remote_addr))
 
-    return joined_table[['requestor', 'remote_addr', 'latency_ns',
-                         'error_rate_pct', 'requests_per_ns']]
+    return joined_table[['requestor', 'remote_addr', 'latency',
+                         'error_rate', 'request_throughput']]
 
 
 def let_helper(start_time: str):
@@ -278,8 +272,8 @@ def let_helper(start_time: str):
     '''
     df = px.DataFrame(table='http_events', start_time=start_time)
     df.pod = df.ctx['pod']
-    df.latency_ns = df.http_resp_latency_ns
-    df = df[df['latency_ns'] < (10000 * 1000000)]
+    df.latency = df.http_resp_latency_ns
+    df = df[df['latency'] < (10000 * ns_per_ms)]
     df.timestamp = px.bin(df.time_, window_ns)
 
     df.resp_size = px.length(df.http_resp_body)

--- a/pxl_scripts/px/pod/vis.json
+++ b/pxl_scripts/px/pod/vis.json
@@ -87,7 +87,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "requests_per_s",
+            "value": "requests_per_ns",
             "mode": "MODE_AREA",
             "series": "container",
             "stackBySeries": true
@@ -113,7 +113,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "errors_per_s",
+            "value": "errors_per_ns",
             "mode": "MODE_AREA",
             "series": "container",
             "stackBySeries": true
@@ -247,11 +247,11 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "rx_mb_per_s",
+            "value": "rx_bytes_per_ns",
             "mode": "MODE_LINE"
           },
           {
-            "value": "tx_mb_per_s",
+            "value": "tx_bytes_per_ns",
             "mode": "MODE_LINE"
           }
         ],
@@ -275,7 +275,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "rchar_mb_per_s",
+            "value": "rchar_bytes_per_ns",
             "mode": "MODE_AREA",
             "series": "container",
             "stackBySeries": true
@@ -301,7 +301,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "wchar_mb_per_s",
+            "value": "wchar_bytes_per_ns",
             "mode": "MODE_AREA",
             "series": "container",
             "stackBySeries": true
@@ -327,7 +327,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "rss_mb",
+            "value": "rss_bytes",
             "mode": "MODE_AREA",
             "series": "container",
             "stackBySeries": true
@@ -353,7 +353,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "vsize_mb",
+            "value": "vsize_bytes",
             "mode": "MODE_AREA",
             "series": "container",
             "stackBySeries": true

--- a/pxl_scripts/px/pod/vis.json
+++ b/pxl_scripts/px/pod/vis.json
@@ -87,7 +87,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "requests_per_ns",
+            "value": "request_throughput",
             "mode": "MODE_AREA",
             "series": "container",
             "stackBySeries": true
@@ -95,7 +95,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "requests per s"
+          "label": "request throughput"
         },
         "xAxis": null
       },
@@ -121,7 +121,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "errors per s"
+          "label": "error rate"
         },
         "xAxis": null
       },
@@ -171,7 +171,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "cpu_pct",
+            "value": "cpu_usage",
             "mode": "MODE_AREA",
             "series": "container",
             "stackBySeries": true
@@ -179,7 +179,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "CPU %"
+          "label": "CPU usage"
         },
         "xAxis": null
       },
@@ -257,7 +257,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "MB per s"
+          "label": "Network throughput"
         },
         "xAxis": null
       },
@@ -275,7 +275,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "rchar_bytes_per_ns",
+            "value": "total_disk_read_throughput",
             "mode": "MODE_AREA",
             "series": "container",
             "stackBySeries": true
@@ -283,7 +283,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "MB per s"
+          "label": "Disk Read Throughput"
         },
         "xAxis": null
       },
@@ -301,7 +301,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "wchar_bytes_per_ns",
+            "value": "total_disk_write_throughput",
             "mode": "MODE_AREA",
             "series": "container",
             "stackBySeries": true
@@ -309,7 +309,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "MB per s"
+          "label": "Disk Write Throughput"
         },
         "xAxis": null
       },
@@ -327,7 +327,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "rss_bytes",
+            "value": "rss",
             "mode": "MODE_AREA",
             "series": "container",
             "stackBySeries": true
@@ -335,7 +335,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "MB"
+          "label": "RSS"
         },
         "xAxis": null
       },
@@ -353,7 +353,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "vsize_bytes",
+            "value": "vsize",
             "mode": "MODE_AREA",
             "series": "container",
             "stackBySeries": true
@@ -361,7 +361,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "MB"
+          "label": "vsize"
         },
         "xAxis": null
       },

--- a/pxl_scripts/px/pod_edge_stats/pod_edge_stats.pxl
+++ b/pxl_scripts/px/pod_edge_stats/pod_edge_stats.pxl
@@ -7,7 +7,6 @@ This live view calculates LET between a requesting and responding pod.
 '''
 import px
 
-bytes_per_mb = 1024 * 1024
 ns_per_ms = 1000 * 1000
 ns_per_s = 1000 * ns_per_ms
 # Window size to use on time_ column for bucketing.
@@ -49,14 +48,14 @@ def http_requests(start_time: str, requesting_pod: px.Pod, responding_pod: px.Po
     df = df.merge(remote_ip_table, how='inner', left_on='remote_addr', right_on='remote_addr',
                   suffixes=['_x', '']).drop('remote_addr_x')
 
-    df.latency_ns = df.http_resp_latency_ns
+    df.latency = df.http_resp_latency_ns
     df.timestamp = px.bin(df.time_, window_ns)
     df.failure = df.http_resp_status >= 400
     filter_out_conds = ((df.http_req_path != '/health' or not filter_health_checks) and (
         df.http_req_path != '/readyz' or not filter_ready_checks)) and (
         df['remote_addr'] != '-' or not filter_unresolved_inbound)
     df = df[filter_out_conds]
-    return df[['timestamp', 'latency_ns', 'http_req_method', 'http_req_path', 'http_req_body',
+    return df[['timestamp', 'latency', 'http_req_method', 'http_req_path', 'http_req_body',
                'http_resp_status', 'http_resp_body', 'failure']]
 
 
@@ -83,8 +82,8 @@ def latency_histogram(start_time: str, requesting_pod: px.Pod, responding_pod: p
     @responding_pod: The name of the requesting pod.
     """
     df = http_requests(start_time, requesting_pod, responding_pod)
-    df.request_latency_ns = df.latency_ns
-    return df.groupby('request_latency_ns').agg(count=('timestamp', px.count))
+    df.request_latency = df.latency
+    return df.groupby('request_latency').agg(count=('timestamp', px.count))
 
 
 def pod_edge_let(start_time: str, requesting_pod: px.Pod, responding_pod: px.Pod):
@@ -98,23 +97,23 @@ def pod_edge_let(start_time: str, requesting_pod: px.Pod, responding_pod: px.Pod
     """
 
     df = http_requests(start_time, requesting_pod, responding_pod)
-    df.resp_size = px.length(df.http_resp_body)
-    df.req_size = px.length(df.http_req_body)
+    df.resp_size = px.Bytes(px.length(df.http_resp_body))
+    df.req_size = px.Bytes(px.length(df.http_req_body))
 
     df = df.groupby('timestamp').agg(
-        latency_quantiles=('latency_ns', px.quantiles),
+        latency_quantiles=('latency', px.quantiles),
         error_rate_per_window=('failure', px.mean),
-        throughput_total=('latency_ns', px.count),
+        throughput_total=('latency', px.count),
         bytes_recv=('req_size', px.sum),
         bytes_sent=('resp_size', px.sum)
     )
 
-    df.latency_p50 = px.pluck_float64(df.latency_quantiles, 'p50')
-    df.latency_p90 = px.pluck_float64(df.latency_quantiles, 'p90')
-    df.latency_p99 = px.pluck_float64(df.latency_quantiles, 'p99')
+    df.latency_p50 = px.DurationNanos(px.floor(px.pluck_float64(df.latency_quantiles, 'p50')))
+    df.latency_p90 = px.DurationNanos(px.floor(px.pluck_float64(df.latency_quantiles, 'p90')))
+    df.latency_p99 = px.DurationNanos(px.floor(px.pluck_float64(df.latency_quantiles, 'p99')))
     df['time_'] = df['timestamp']
-    df.requests_per_ns = df.throughput_total / window_ns
-    df.req_mb_per_ns = df.bytes_recv / window_ns
-    df.resp_mb_per_ns = df.bytes_sent / window_ns
-    df.error_rate = df.error_rate_per_window * df.requests_per_ns
+    df.request_throughput = df.throughput_total / window_ns
+    df.req_data_throughput = df.bytes_recv / window_ns
+    df.resp_data_throughput = df.bytes_sent / window_ns
+    df.error_rate = df.error_rate_per_window * df.request_throughput / px.DurationNanos(1)
     return df

--- a/pxl_scripts/px/pod_edge_stats/pod_edge_stats.pxl
+++ b/pxl_scripts/px/pod_edge_stats/pod_edge_stats.pxl
@@ -8,8 +8,10 @@ This live view calculates LET between a requesting and responding pod.
 import px
 
 bytes_per_mb = 1024 * 1024
-# Window in seconds within which to aggregate metrics.
-window_s = 10
+ns_per_ms = 1000 * 1000
+ns_per_s = 1000 * ns_per_ms
+# Window size to use on time_ column for bucketing.
+window_ns = px.DurationNanos(10 * ns_per_s)
 # Flag to filter out requests that come from an unresolvable IP.
 filter_unresolved_inbound = True
 # Flag to filter out health checks from the data.
@@ -19,7 +21,7 @@ filter_ready_checks = True
 # Flag to filter out non_k8s_traffic from the data.
 filter_non_k8s_traffic = True
 # The bin size in milliseconds to use for the latency histogram.
-latency_bin_size_ms = 50
+latency_bin_size_ns = 50 * ns_per_ms
 
 
 def http_requests(start_time: str, requesting_pod: px.Pod, responding_pod: px.Pod):
@@ -47,14 +49,14 @@ def http_requests(start_time: str, requesting_pod: px.Pod, responding_pod: px.Po
     df = df.merge(remote_ip_table, how='inner', left_on='remote_addr', right_on='remote_addr',
                   suffixes=['_x', '']).drop('remote_addr_x')
 
-    df.latency_ms = df.http_resp_latency_ns / 1.0E6
-    df.timestamp = px.bin(df.time_, px.seconds(window_s))
+    df.latency_ns = df.http_resp_latency_ns
+    df.timestamp = px.bin(df.time_, window_ns)
     df.failure = df.http_resp_status >= 400
     filter_out_conds = ((df.http_req_path != '/health' or not filter_health_checks) and (
         df.http_req_path != '/readyz' or not filter_ready_checks)) and (
         df['remote_addr'] != '-' or not filter_unresolved_inbound)
     df = df[filter_out_conds]
-    return df[['timestamp', 'latency_ms', 'http_req_method', 'http_req_path', 'http_req_body',
+    return df[['timestamp', 'latency_ns', 'http_req_method', 'http_req_path', 'http_req_body',
                'http_resp_status', 'http_resp_body', 'failure']]
 
 
@@ -81,8 +83,8 @@ def latency_histogram(start_time: str, requesting_pod: px.Pod, responding_pod: p
     @responding_pod: The name of the requesting pod.
     """
     df = http_requests(start_time, requesting_pod, responding_pod)
-    df.request_latency_ms = df.latency_ms
-    return df.groupby('request_latency_ms').agg(count=('timestamp', px.count))
+    df.request_latency_ns = df.latency_ns
+    return df.groupby('request_latency_ns').agg(count=('timestamp', px.count))
 
 
 def pod_edge_let(start_time: str, requesting_pod: px.Pod, responding_pod: px.Pod):
@@ -100,20 +102,19 @@ def pod_edge_let(start_time: str, requesting_pod: px.Pod, responding_pod: px.Pod
     df.req_size = px.length(df.http_req_body)
 
     df = df.groupby('timestamp').agg(
-        latency_quantiles=('latency_ms', px.quantiles),
+        latency_quantiles=('latency_ns', px.quantiles),
         error_rate_per_window=('failure', px.mean),
-        throughput_total=('latency_ms', px.count),
+        throughput_total=('latency_ns', px.count),
         bytes_recv=('req_size', px.sum),
         bytes_sent=('resp_size', px.sum)
     )
 
-    window_size = window_s * 1.0
     df.latency_p50 = px.pluck_float64(df.latency_quantiles, 'p50')
     df.latency_p90 = px.pluck_float64(df.latency_quantiles, 'p90')
     df.latency_p99 = px.pluck_float64(df.latency_quantiles, 'p99')
     df['time_'] = df['timestamp']
-    df.rps = df.throughput_total / window_size
-    df.req_mb_per_s = df.bytes_recv / (window_size * bytes_per_mb)
-    df.resp_mb_per_s = df.bytes_sent / (window_size * bytes_per_mb)
-    df.error_rate = df.error_rate_per_window * df.rps
+    df.requests_per_ns = df.throughput_total / window_ns
+    df.req_mb_per_ns = df.bytes_recv / window_ns
+    df.resp_mb_per_ns = df.bytes_sent / window_ns
+    df.error_rate = df.error_rate_per_window * df.requests_per_ns
     return df

--- a/pxl_scripts/px/pod_edge_stats/vis.json
+++ b/pxl_scripts/px/pod_edge_stats/vis.json
@@ -69,7 +69,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "latency (ms)"
+          "label": "latency"
         },
         "xAxis": null
       }
@@ -87,13 +87,13 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "rps",
+            "value": "request_throughput",
             "mode": "MODE_LINE"
           }
         ],
         "title": "",
         "yAxis": {
-          "label": "requests per s"
+          "label": "request throughput"
         },
         "xAxis": null
       }
@@ -117,7 +117,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "Error Rate (%)"
+          "label": "Error Rate"
         },
         "xAxis": null
       }
@@ -135,17 +135,17 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "resp_mb_per_s",
+            "value": "resp_data_throughput",
             "mode": "MODE_LINE"
           },
           {
-            "value": "req_mb_per_s",
+            "value": "req_data_throughput",
             "mode": "MODE_LINE"
           }
         ],
         "title": "",
         "yAxis": {
-          "label": "MB per s"
+          "label": "http throughtput"
         },
         "xAxis": null
       }
@@ -218,13 +218,13 @@
       "displaySpec": {
         "@type": "pixielabs.ai/pl.vispb.HistogramChart",
         "histogram": {
-          "value": "request_latency_ms",
+          "value": "request_latency",
           "prebinCount": "count",
           "maxbins": 10,
           "minstep": 50.0
         },
         "xAxis": {
-          "label": "Request Latency (ms)"
+          "label": "Request Latency"
         },
         "yAxis": {
           "label": "# of requests"

--- a/pxl_scripts/px/pod_lifetime_resource/resource.pxl
+++ b/pxl_scripts/px/pod_lifetime_resource/resource.pxl
@@ -7,61 +7,49 @@ import px
 # Returns the Total Resource Usage for each pod.
 #
 t1 = px.DataFrame(table='process_stats', start_time='-60s')
-
-bytes_per_mb = 1024.0 * 1024.0
-
-# Convert to better units.
-t1.cpu_utime_s = t1.cpu_utime_ns / 1.0E9
-t1.cpu_ktime_s = t1.cpu_ktime_ns / 1.0E9
-t1.vsize_mb = t1.vsize_bytes / bytes_per_mb
-t1.rss_bytes_mb = t1.rss_bytes / bytes_per_mb
-t1.read_bytes_mb = t1.read_bytes / bytes_per_mb
-t1.write_bytes_mb = t1.write_bytes / bytes_per_mb
-t1.rchar_bytes_mb = t1.rchar_bytes / bytes_per_mb
-t1.wchar_bytes_mb = t1.wchar_bytes / bytes_per_mb
 t1.pod = t1.ctx['pod']
 
 upid_aggop = t1.groupby(['upid', 'pod']).agg(
-    vsize_mb=('vsize_mb', px.mean),
-    rss_bytes_mb=('rss_bytes_mb', px.mean),
+    vsize=('vsize_bytes', px.mean),
+    rss=('rss_bytes', px.mean),
     # The following columns are all counters, so we take the maximum value.
-    cpu_utime_s=('cpu_utime_s', px.max),
-    cpu_ktime_s=('cpu_ktime_s', px.max),
-    read_bytes_mb=('read_bytes_mb', px.max),
-    write_bytes_mb=('write_bytes_mb', px.max),
-    rchar_bytes_mb=('rchar_bytes_mb', px.max),
-    wchar_bytes_mb=('wchar_bytes_mb', px.max),
+    cpu_utime_ns=('cpu_utime_ns', px.max),
+    cpu_ktime_ns=('cpu_ktime_ns', px.max),
+    read_bytes=('read_bytes', px.max),
+    write_bytes=('write_bytes', px.max),
+    rchar_bytes=('rchar_bytes', px.max),
+    wchar_bytes=('wchar_bytes', px.max),
 )
 
 # For this aggregate, we sum up the values as we've already calculated the average/usage
 # for the upids already.
 pod_aggop = upid_aggop.groupby('pod').agg(
-    cpu_utime_s=('cpu_utime_s', px.sum),
-    cpu_ktime_s=('cpu_ktime_s', px.sum),
-    vsize_mb=('vsize_mb', px.sum),
-    rss_bytes_mb=('rss_bytes_mb', px.sum),
-    read_bytes_mb=('read_bytes_mb', px.sum),
-    write_bytes_mb=('write_bytes_mb', px.sum),
-    rchar_bytes_mb=('rchar_bytes_mb', px.sum),
-    wchar_bytes_mb=('wchar_bytes_mb', px.sum),
+    cpu_utime_ns=('cpu_utime_ns', px.sum),
+    cpu_ktime_ns=('cpu_ktime_ns', px.sum),
+    vsize=('vsize', px.sum),
+    rss=('rss', px.sum),
+    read_bytes=('read_bytes', px.sum),
+    write_bytes=('write_bytes', px.sum),
+    rchar_bytes=('rchar_bytes', px.sum),
+    wchar_bytes=('wchar_bytes', px.sum),
 )
 
 # Format everything nicely.
 pod_aggop.pod_name = pod_aggop.pod
 pod_aggop.status = px.pod_name_to_status(pod_aggop.pod_name)
 pod_aggop['Created on'] = px.pod_name_to_start_time(pod_aggop.pod_name)
-pod_aggop['CPU User time (s)'] = pod_aggop.cpu_utime_s
-pod_aggop['CPU System time (s)'] = pod_aggop.cpu_ktime_s
-pod_aggop['Virtual Memory (mb)'] = pod_aggop.vsize_mb
-pod_aggop['Average Memory (mb)'] = pod_aggop.rss_bytes_mb
-pod_aggop['Read to IO (mb)'] = pod_aggop.read_bytes_mb
-pod_aggop['Write to IO (mb)'] = pod_aggop.write_bytes_mb
-pod_aggop['Characters Read (mb)'] = pod_aggop.rchar_bytes_mb
-pod_aggop['Characters written (mb)'] = pod_aggop.wchar_bytes_mb
+pod_aggop['CPU User time'] = px.DurationNanos(pod_aggop.cpu_utime_ns)
+pod_aggop['CPU System time'] = px.DurationNanos(pod_aggop.cpu_ktime_ns)
+pod_aggop['Virtual Memory'] = pod_aggop.vsize
+pod_aggop['Average Memory'] = pod_aggop.rss
+pod_aggop['Read to IO'] = pod_aggop.read_bytes
+pod_aggop['Write to IO'] = pod_aggop.write_bytes
+pod_aggop['Characters Read'] = pod_aggop.rchar_bytes
+pod_aggop['Characters written'] = pod_aggop.wchar_bytes
 
-keep_columns = pod_aggop[['pod_name', 'status', 'Created on', 'CPU User time (s)',
-                          'CPU System time (s)', 'Virtual Memory (mb)',
-                          'Average Memory (mb)', 'Read to IO (mb)', 'Write to IO (mb)',
-                          'Characters Read (mb)', 'Characters written (mb)']]
+keep_columns = pod_aggop[['pod_name', 'status', 'Created on', 'CPU User time',
+                          'CPU System time', 'Virtual Memory',
+                          'Average Memory', 'Read to IO', 'Write to IO',
+                          'Characters Read', 'Characters written']]
 
 px.display(keep_columns)

--- a/pxl_scripts/px/pod_memory_usage/pod.pxl
+++ b/pxl_scripts/px/pod_memory_usage/pod.pxl
@@ -20,34 +20,31 @@ match_name = ''
 # in the cluster.
 #
 t1 = px.DataFrame(table='process_stats', start_time='-1m')
-bytes_per_mb = 1024.0 * 1024.0
-t1.vsize_mb = t1.vsize_bytes / bytes_per_mb
-t1.rss_bytes_mb = t1.rss_bytes / bytes_per_mb
 t1.timestamp = px.bin(t1.time_, px.seconds(10))
 t1[k8s_object] = t1.ctx[k8s_object]
 
 t1 = t1[px.contains(t1[k8s_object], match_name)]
 
 upid_aggop = t1.groupby(['upid', k8s_object, 'timestamp']).agg(
-    vsize_mb=('vsize_mb', px.mean),
-    rss_bytes_mb=('rss_bytes_mb', px.mean),
+    vsize=('vsize_bytes', px.mean),
+    rss=('rss_bytes', px.mean),
 )
 
 # For this aggregate, we sum up the values as we've already calculated the average/usage
 # for the upids already, just need to do it for the entire svc.
 aggop = upid_aggop.groupby([k8s_object, 'timestamp']).agg(
-    vsize_mb=('vsize_mb', px.sum),
-    rss_bytes_mb=('rss_bytes_mb', px.sum),
+    vsize=('vsize', px.sum),
+    rss=('rss', px.sum),
 )
 
 # Format column names.
-aggop['Virtual Memory (mb)'] = aggop.vsize_mb
-aggop['Average Memory (mb)'] = aggop.rss_bytes_mb
+aggop['Virtual Memory'] = aggop.vsize
+aggop['Average Memory'] = aggop.rss
 keep_columns = aggop[[
     k8s_object,
     'timestamp',
-    'Virtual Memory (mb)',
-    'Average Memory (mb)'
+    'Virtual Memory',
+    'Average Memory'
 ]]
 
 px.display(keep_columns)

--- a/pxl_scripts/px/pods/pods.pxl
+++ b/pxl_scripts/px/pods/pods.pxl
@@ -12,8 +12,10 @@ import px
 
 
 bytes_per_mb = 1024.0 * 1024.0
-# Window size for computing timeseries
-window_s = 10
+ns_per_ms = 1000 * 1000
+ns_per_s = 1000 * ns_per_ms
+# Window size to use on time_ column for bucketing.
+window_ns = px.DurationNanos(10 * ns_per_s)
 # Flag to filter out requests that come from an unresolvable IP.
 filter_unresolved_inbound = True
 # Flag to filter out health checks from the data.

--- a/pxl_scripts/px/pods/pods.pxl
+++ b/pxl_scripts/px/pods/pods.pxl
@@ -11,7 +11,6 @@ List of Pods monitored by Pixie in a given Namespace with their high level appli
 import px
 
 
-bytes_per_mb = 1024.0 * 1024.0
 ns_per_ms = 1000 * 1000
 ns_per_s = 1000 * ns_per_ms
 # Window size to use on time_ column for bucketing.
@@ -55,67 +54,52 @@ def resource_timeseries(start_time: str, namespace: px.Namespace):
     df = px.DataFrame(table='process_stats', start_time=start_time)
     df = df[df.ctx['namespace'] == namespace]
     df.pod = df.ctx['pod_name']
-    df.timestamp = px.bin(df.time_, px.seconds(window_s))
-
-    # Convert bytes to MB.
-    df.vsize_mb = df.vsize_bytes / bytes_per_mb
-    df.rss_mb = df.rss_bytes / bytes_per_mb
-    df.read_mb = df.read_bytes / bytes_per_mb
-    df.write_mb = df.write_bytes / bytes_per_mb
-    df.rchar_mb = df.rchar_bytes / bytes_per_mb
-    df.wchar_mb = df.wchar_bytes / bytes_per_mb
-
-    # Convert nanoseconds to milliseconds.
-    df.cpu_utime_ms = df.cpu_utime_ns / 1.0E6
-    df.cpu_ktime_ms = df.cpu_ktime_ns / 1.0E6
+    df.timestamp = px.bin(df.time_, window_ns)
 
     # First calculate CPU usage by process (UPID) in each k8s_object
     # over all windows.
     df = df.groupby(['upid', 'pod', 'timestamp']).agg(
-        rss_mb=('rss_mb', px.mean),
-        vsize_mb=('vsize_mb', px.mean),
+        rss=('rss_bytes', px.mean),
+        vsize=('vsize_bytes', px.mean),
         # The fields below are counters, so we take the min and the max to subtract them.
-        cpu_utime_ms_max=('cpu_utime_ms', px.max),
-        cpu_utime_ms_min=('cpu_utime_ms', px.min),
-        cpu_ktime_ms_max=('cpu_ktime_ms', px.max),
-        cpu_ktime_ms_min=('cpu_ktime_ms', px.min),
-        read_mb_max=('read_mb', px.max),
-        read_mb_min=('read_mb', px.min),
-        write_mb_max=('write_mb', px.max),
-        write_mb_min=('write_mb', px.min),
-        rchar_mb_max=('rchar_mb', px.max),
-        rchar_mb_min=('rchar_mb', px.min),
-        wchar_mb_max=('wchar_mb', px.max),
-        wchar_mb_min=('wchar_mb', px.min),
+        cpu_utime_ns_max=('cpu_utime_ns', px.max),
+        cpu_utime_ns_min=('cpu_utime_ns', px.min),
+        cpu_ktime_ns_max=('cpu_ktime_ns', px.max),
+        cpu_ktime_ns_min=('cpu_ktime_ns', px.min),
+        read_bytes_max=('read_bytes', px.max),
+        read_bytes_min=('read_bytes', px.min),
+        write_bytes_max=('write_bytes', px.max),
+        write_bytes_min=('write_bytes', px.min),
+        rchar_bytes_max=('rchar_bytes', px.max),
+        rchar_bytes_min=('rchar_bytes', px.min),
+        wchar_bytes_max=('wchar_bytes', px.max),
+        wchar_bytes_min=('wchar_bytes', px.min),
     )
 
-    window_size = 1.0 * window_s
     # Next calculate cpu usage and memory stats per window.
-    df.cpu_utime_ms = df.cpu_utime_ms_max - df.cpu_utime_ms_min
-    df.cpu_ktime_ms = df.cpu_ktime_ms_max - df.cpu_ktime_ms_min
-    df.read_mb_per_s = (df.read_mb_max - df.read_mb_min) / window_size
-    df.write_mb_per_s = (df.write_mb_max - df.write_mb_min) / window_size
-    df.rchar_mb_per_s = (df.rchar_mb_max - df.rchar_mb_min) / window_size
-    df.wchar_mb_per_s = (df.wchar_mb_max - df.wchar_mb_min) / window_size
+    df.cpu_utime_ns = df.cpu_utime_ns_max - df.cpu_utime_ns_min
+    df.cpu_ktime_ns = df.cpu_ktime_ns_max - df.cpu_ktime_ns_min
+    df.actual_disk_read_throughput = (df.read_bytes_max - df.read_bytes_min) / window_ns
+    df.actual_disk_write_throughput = (df.write_bytes_max - df.write_bytes_min) / window_ns
+    df.total_disk_read_throughput = (df.rchar_bytes_max - df.rchar_bytes_min) / window_ns
+    df.total_disk_write_throughput = (df.wchar_bytes_max - df.wchar_bytes_min) / window_ns
 
     # Then aggregate process individual process metrics.
     df = df.groupby(['pod', 'timestamp']).agg(
-        cpu_ktime_ms=('cpu_ktime_ms', px.sum),
-        cpu_utime_ms=('cpu_utime_ms', px.sum),
-        read_mb_per_s=('read_mb_per_s', px.sum),
-        write_mb_per_s=('write_mb_per_s', px.sum),
-        rchar_mb_per_s=('rchar_mb_per_s', px.sum),
-        wchar_mb_per_s=('wchar_mb_per_s', px.sum),
-        rss_mb=('rss_mb', px.sum),
-        vsize_mb=('vsize_mb', px.sum),
+        cpu_ktime_ns=('cpu_ktime_ns', px.sum),
+        cpu_utime_ns=('cpu_utime_ns', px.sum),
+        actual_disk_read_throughput=('actual_disk_read_throughput', px.sum),
+        actual_disk_write_throughput=('actual_disk_write_throughput', px.sum),
+        total_disk_read_throughput=('total_disk_read_throughput', px.sum),
+        total_disk_write_throughput=('total_disk_write_throughput', px.sum),
+        rss=('rss', px.sum),
+        vsize=('vsize', px.sum),
     )
 
-    # Convert window_s into the same units as cpu time.
-    window_size_ms = window_s * 1.0E3
     # Finally, calculate total (kernel + user time)  percentage used over window.
-    df.cpu_pct = (df.cpu_ktime_ms + df.cpu_utime_ms) / window_size_ms * 100
+    df.cpu_usage = px.Percent((df.cpu_ktime_ns + df.cpu_utime_ns) / window_ns)
     df['time_'] = df['timestamp']
-    return df.drop(['cpu_ktime_ms', 'cpu_utime_ms', 'timestamp'])
+    return df.drop(['cpu_ktime_ns', 'cpu_utime_ns', 'timestamp'])
 
 
 def inbound_let_timeseries(start_time: str, namespace: px.Namespace):
@@ -129,25 +113,24 @@ def inbound_let_timeseries(start_time: str, namespace: px.Namespace):
     df = inbound_let_helper(start_time, namespace)
 
     df = df.groupby(['pod', 'timestamp']).agg(
-        latency_quantiles=('latency_ms', px.quantiles),
+        latency_quantiles=('latency', px.quantiles),
         error_rate_per_window=('failure', px.mean),
-        throughput_total=('latency_ms', px.count),
+        throughput_total=('latency', px.count),
         bytes_total=('resp_size', px.sum)
     )
 
     # Format the result of LET aggregates into proper scalar formats and
     # time series.
-    window_size = window_s * 1.0
-    df.latency_p50 = px.pluck_float64(df.latency_quantiles, 'p50')
-    df.latency_p90 = px.pluck_float64(df.latency_quantiles, 'p90')
-    df.latency_p99 = px.pluck_float64(df.latency_quantiles, 'p99')
-    df.requests_per_s = df.throughput_total / window_size
-    df.error_rate_pct = df.error_rate_per_window * 100
-    df.bytes_per_s = df.bytes_total / window_size
+    df.latency_p50 = px.DurationNanos(px.floor(px.pluck_float64(df.latency_quantiles, 'p50')))
+    df.latency_p90 = px.DurationNanos(px.floor(px.pluck_float64(df.latency_quantiles, 'p90')))
+    df.latency_p99 = px.DurationNanos(px.floor(px.pluck_float64(df.latency_quantiles, 'p99')))
+    df.request_throughput = df.throughput_total / window_ns
+    df.error_rate = px.Percent(df.error_rate_per_window)
+    df.bytes_per_ns = df.bytes_total / window_ns
     df.time_ = df.timestamp
 
     return df[['time_', 'pod', 'latency_p50', 'latency_p90', 'latency_p99',
-               'requests_per_s', 'error_rate_pct', 'bytes_per_s']]
+               'request_throughput', 'error_rate', 'bytes_per_ns']]
 
 
 def inbound_let_summary(start_time: str, namespace: px.Namespace):
@@ -160,10 +143,10 @@ def inbound_let_summary(start_time: str, namespace: px.Namespace):
     df = inbound_let_helper(start_time, namespace)
 
     quantiles_agg = df.groupby(['pod', 'remote_addr']).agg(
-        latency_ms=('latency_ms', px.quantiles),
-        total_request_count=('latency_ms', px.count)
+        latency=('latency', px.quantiles),
+        total_request_count=('latency', px.count)
     )
-    quantiles_table = quantiles_agg[['pod', 'remote_addr', 'latency_ms',
+    quantiles_table = quantiles_agg[['pod', 'remote_addr', 'latency',
                                      'total_request_count']]
 
     range_agg = df.groupby(['pod', 'remote_addr', 'timestamp']).agg(
@@ -182,14 +165,14 @@ def inbound_let_summary(start_time: str, namespace: px.Namespace):
                                          right_on=['pod', 'remote_addr'],
                                          suffixes=['', '_x'])
 
-    joined_table.error_rate_pct = 100 * joined_table.error_rate
-    joined_table.requests_per_s = joined_table.requests_per_window / (1.0 * window_s)
+    joined_table.error_rate = px.Percent(joined_table.error_rate)
+    joined_table.request_throughput = joined_table.requests_per_window / window_ns
 
     joined_table.responder = df.pod
     joined_table.requestor = px.pod_id_to_pod_name(px.ip_to_pod_id(df.remote_addr))
 
-    return joined_table[['responder', 'requestor', 'latency_ms', 'error_rate_pct',
-                         'requests_per_s']]
+    return joined_table[['responder', 'requestor', 'latency', 'error_rate',
+                         'request_throughput']]
 
 
 def inbound_let_helper(start_time: str, namespace: px.Namespace):
@@ -204,11 +187,11 @@ def inbound_let_helper(start_time: str, namespace: px.Namespace):
     df = df[df.ctx['namespace'] == namespace]
     df.pod = df.ctx['pod']
     df = df[df.pod != '']
-    df.latency_ms = df.http_resp_latency_ns / 1.0E6
-    df = df[df['latency_ms'] < 10000.0]
-    df.timestamp = px.bin(df.time_, px.seconds(window_s))
+    df.latency = df.http_resp_latency_ns
+    df = df[df['latency'] < (10000 * ns_per_ms)]
+    df.timestamp = px.bin(df.time_, window_ns)
 
-    df.resp_size = px.length(df.http_resp_body)
+    df.resp_size = px.Bytes(px.length(df.http_resp_body))
     df.failure = df.http_resp_status >= 400
     filter_out_conds = ((df.http_req_path != '/health' or not filter_health_checks) and (
         df.http_req_path != '/readyz' or not filter_ready_checks)) and (

--- a/pxl_scripts/px/pods/vis.json
+++ b/pxl_scripts/px/pods/vis.json
@@ -80,7 +80,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "requests_per_s",
+            "value": "request_throughput",
             "series": "pod",
             "stackBySeries": false,
             "mode": "MODE_LINE"
@@ -88,7 +88,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "requests per second"
+          "label": "request throughput"
         },
         "xAxis": null
       },
@@ -114,7 +114,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "P50 Latency (ms)"
+          "label": "P50 Latency"
         },
         "xAxis": null
       },
@@ -140,7 +140,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "P90 Latency (ms)"
+          "label": "P90 Latency"
         },
         "xAxis": null
       },
@@ -166,7 +166,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "P99 Latency (ms)"
+          "label": "P99 Latency"
         },
         "xAxis": null
       },
@@ -184,7 +184,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "error_rate_pct",
+            "value": "error_rate",
             "series": "pod",
             "stackBySeries": false,
             "mode": "MODE_LINE"
@@ -192,7 +192,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "error rate (%)"
+          "label": "error rate"
         },
         "xAxis": null
       },
@@ -210,7 +210,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "cpu_pct",
+            "value": "cpu_usage",
             "series": "pod",
             "stackBySeries": false,
             "mode": "MODE_LINE"
@@ -218,7 +218,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "CPU (%)"
+          "label": "CPU usage"
         },
         "xAxis": null
       },
@@ -236,7 +236,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "rss_mb",
+            "value": "rss",
             "series": "pod",
             "stackBySeries": false,
             "mode": "MODE_LINE"
@@ -244,7 +244,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "RSS Size (MB)"
+          "label": "RSS Size"
         },
         "xAxis": null
       },
@@ -262,7 +262,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "rchar_mb_per_s",
+            "value": "total_disk_read_throughput",
             "series": "pod",
             "stackBySeries": false,
             "mode": "MODE_LINE"
@@ -270,7 +270,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "bytes (MB/s)"
+          "label": "bytes read"
         },
         "xAxis": null
       },
@@ -288,7 +288,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "wchar_mb_per_s",
+            "value": "total_disk_write_throughput",
             "series": "pod",
             "stackBySeries": false,
             "mode": "MODE_LINE"
@@ -296,7 +296,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "bytes (MB/s)"
+          "label": "bytes written"
         },
         "xAxis": null
       },

--- a/pxl_scripts/px/psql_data/data.pxl
+++ b/pxl_scripts/px/psql_data/data.pxl
@@ -5,8 +5,7 @@ import px
 
 t1 = px.DataFrame(table='pgsql_events', select=['time_', 'remote_addr', 'remote_port',
                                                 'req', 'resp', 'latency_ns'], start_time='-30s')
-
-t1.latency_ms = t1.latency_ns / 1.0E6
-t2 = t1.drop(columns=['latency_ns']).head(n=100)
+t1.latency = px.DurationNanos(t1.latency_ns)
+t2 = t1.drop(['latency_ns']).head(n=100)
 
 px.display(t2)

--- a/pxl_scripts/px/psql_stats/pgsql_stats.pxl
+++ b/pxl_scripts/px/psql_stats/pgsql_stats.pxl
@@ -32,7 +32,7 @@ ip_col_name = 'PostgreSQL IP'
 # Temporary way to ensure px.Pod works as expected.
 px.Pod = str
 # The bin size to use for the latency histogram.
-latency_bin_size_ms = 50
+latency_bin_size_ns = px.DurationNanos(50 * ns_per_ms)
 # ----------------------------------------------------------------
 
 
@@ -56,7 +56,7 @@ def pod_pgsql_let(start: str, pod: px.Pod):
     '''
     df = pgsql_let_per_pod(start, pod, ['timestamp', k8s_object])
     return df['time_', split_series_name, 'latency_p50',
-              'latency_p90', 'latency_p99', 'rps']
+              'latency_p90', 'latency_p99', 'request_throughput']
 
 
 def summary_pgsql_let(start: str, pod: px.Pod):
@@ -74,7 +74,7 @@ def summary_pgsql_let(start: str, pod: px.Pod):
     df = pgsql_let_per_pod(start, pod, ['timestamp', k8s_object, 'remote_addr'])
     df[ip_col_name] = df.remote_addr
     summary_df = summarize_LET(df, [k8s_object, ip_col_name])
-    return summary_df[[k8s_object, ip_col_name, 'rps', 'latency', 'total_requests']]
+    return summary_df[[k8s_object, ip_col_name, 'request_throughput', 'latency', 'total_requests']]
 
 
 def latency_histogram(start: str, pod: px.Pod):
@@ -97,9 +97,9 @@ def latency_histogram(start: str, pod: px.Pod):
     # over the time window ('timestamp') after filtering for matching svcs.
     matching_df = df[px.contains(df[k8s_object], pod)]
 
-    matching_df.request_latency_ms = px.bin(matching_df.latency_ns / 1000 / 1000,
-                                            latency_bin_size_ms)
-    return matching_df.groupby('request_latency_ms').agg(count=('time_', px.count))
+    matching_df.request_latency = px.bin(matching_df.latency,
+                                         latency_bin_size_ns)
+    return matching_df.groupby('request_latency').agg(count=('time_', px.count))
 
 
 # ----------------------------------------------------------------
@@ -135,7 +135,7 @@ def pgsql_let_per_pod(start: str, pod: px.Pod, groups):
     return let_df
 
 
-def format_events_table(df, latency_ns_col):
+def format_events_table(df, latency_col):
     ''' Format data and add semantic columns in event tables
 
     Unifies latency column to 'latency_ms', adds a binned
@@ -146,13 +146,13 @@ def format_events_table(df, latency_ns_col):
 
     Args:
     @df: the input events table
-    @latency_ns_col: the name of the latency column in @df.
+    @latency_col: the name of the latency column in @df.
 
     Returns: formatted events DataFrame
     '''
-    df.latency_ms = df[latency_ns_col] / 1.0E6
-    df = df[df['latency_ms'] < 10000.0]
-    df.timestamp = px.bin(df.time_, px.seconds(window_s))
+    df.latency = df[latency_col]
+    df = df[df['latency'] < (10000 * ns_per_ms)]
+    df.timestamp = px.bin(df.time_, window_ns)
     df[k8s_object] = df.ctx[k8s_object]
     df = df[df[k8s_object] != '']
     return df
@@ -176,7 +176,7 @@ def format_LET_aggs(df):
 
     Converts the result of aggregates on windows into well-formatted metrics that
     can be visualized. Latency quantile values need to be extracted from the
-    quantiles struct, and then rps and bytes_per_s are calculated as
+    quantiles struct, and then request_throughput and bytes_per_ns are calculated as
     a function of window size.
 
 
@@ -185,18 +185,16 @@ def format_LET_aggs(df):
 
     Args:
     @df: the input events table grouped into windows with aggregated
-        columns 'throughput_total' and 'rps'
+        columns 'throughput_total' and 'request_throughput'
 
     Returns: DataFrame with formatted LET metrics.
     '''
-    window_size = window_s * 1.0
-
-    df.latency_p50 = px.pluck_float64(df.latency_quantiles, 'p50')
-    df.latency_p90 = px.pluck_float64(df.latency_quantiles, 'p90')
-    df.latency_p99 = px.pluck_float64(df.latency_quantiles, 'p99')
+    df.latency_p50 = px.DurationNanos(px.floor(px.pluck_float64(df.latency_quantiles, 'p50')))
+    df.latency_p90 = px.DurationNanos(px.floor(px.pluck_float64(df.latency_quantiles, 'p90')))
+    df.latency_p99 = px.DurationNanos(px.floor(px.pluck_float64(df.latency_quantiles, 'p99')))
     df['time_'] = df['timestamp']
-    df.rps = df.throughput_total / window_size
-    df.bytes_per_s = df.bytes_total / window_size
+    df.request_throughput = df.throughput_total / window_ns
+    df.bytes_per_ns = df.bytes_total / window_ns
 
     return df
 
@@ -216,9 +214,9 @@ def calc_pgsql_LET(df, groups):
     '''
     # All requests for errors and throughput
     df = df.groupby(groups).agg(
-        latency_quantiles=('latency_ms', px.quantiles),
+        latency_quantiles=('latency', px.quantiles),
         bytes_total=('resp_size', px.sum),
-        throughput_total=('latency_ms', px.count)
+        throughput_total=('latency', px.count)
     )
 
     # Format the result of LET aggregates into proper scalar formats and
@@ -256,8 +254,8 @@ def summarize_LET(let_df, groups):
     Returns: The summary DF.
     '''
     df = let_df.groupby(groups).agg(
-        rps=('rps', px.mean),
-        bytes_per_s=('bytes_per_s', px.mean),
+        request_throughput=('request_throughput', px.mean),
+        bytes_per_ns=('bytes_per_ns', px.mean),
         total_requests=('throughput_total', px.sum),
         latency=('latency_p50', px.mean),
     )

--- a/pxl_scripts/px/psql_stats/pgsql_stats.pxl
+++ b/pxl_scripts/px/psql_stats/pgsql_stats.pxl
@@ -97,8 +97,8 @@ def latency_histogram(start: str, pod: px.Pod):
     # over the time window ('timestamp') after filtering for matching svcs.
     matching_df = df[px.contains(df[k8s_object], pod)]
 
-    matching_df.request_latency = px.bin(matching_df.latency,
-                                         latency_bin_size_ns)
+    matching_df.request_latency = px.DurationNanos(px.bin(matching_df.latency,
+                                                          latency_bin_size_ns))
     return matching_df.groupby('request_latency').agg(count=('time_', px.count))
 
 

--- a/pxl_scripts/px/psql_stats/pgsql_stats.pxl
+++ b/pxl_scripts/px/psql_stats/pgsql_stats.pxl
@@ -19,8 +19,10 @@ import px
 # K8s object is the abstraction to group on.
 # Options are ['pod', 'service'].
 k8s_object = 'pod'
-# Window in seconds within which to aggregate metrics.
-window_s = 10
+ns_per_ms = 1000 * 1000
+ns_per_s = 1000 * ns_per_ms
+# Window size to use on time_ column for bucketing.
+window_ns = px.DurationNanos(10 * ns_per_s)
 # Column naem used to split data into separate time series.
 # k8s_object column is renamed to this and is used in
 # visualization spec.

--- a/pxl_scripts/px/psql_stats/vis.json
+++ b/pxl_scripts/px/psql_stats/vis.json
@@ -157,7 +157,7 @@
           "value": "request_latency",
           "prebinCount": "count",
           "maxbins": 10,
-          "minstep": 50.0
+          "minstep": 50000000
         },
         "xAxis": {
           "label": "Request Latency"

--- a/pxl_scripts/px/psql_stats/vis.json
+++ b/pxl_scripts/px/psql_stats/vis.json
@@ -53,7 +53,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "P50 Latency (ms)"
+          "label": "P50 Latency"
         },
         "xAxis": null
       }
@@ -79,7 +79,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "P90 Latency (ms)"
+          "label": "P90 Latency"
         },
         "xAxis": null
       }
@@ -105,7 +105,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "P99 Latency (ms)"
+          "label": "P99 Latency"
         },
         "xAxis": null
       }
@@ -123,7 +123,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "rps",
+            "value": "request_throughput",
             "series": "k8s",
             "stackBySeries": false,
             "mode": "MODE_LINE"
@@ -131,7 +131,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "RPS"
+          "label": "Request throughput"
         },
         "xAxis": null
       }
@@ -154,13 +154,13 @@
       "displaySpec": {
         "@type": "pixielabs.ai/pl.vispb.HistogramChart",
         "histogram": {
-          "value": "request_latency_ms",
+          "value": "request_latency",
           "prebinCount": "count",
           "maxbins": 10,
           "minstep": 50.0
         },
         "xAxis": {
-          "label": "Request Latency (ms)"
+          "label": "Request Latency"
         },
         "yAxis": {
           "label": "# of requests"

--- a/pxl_scripts/px/service/service.pxl
+++ b/pxl_scripts/px/service/service.pxl
@@ -8,8 +8,10 @@
 
 import px
 
-# Window in seconds within which to aggregate metrics.
-window_s = 10
+ns_per_ms = 1000 * 1000
+ns_per_s = 1000 * ns_per_ms
+# Window size to use on time_ column for bucketing.
+window_ns = px.DurationNanos(10 * ns_per_s)
 # Flag to filter out requests that come from an unresolvable IP.
 filter_unresolved_inbound = True
 # Flag to filter out health checks from the data.
@@ -141,7 +143,7 @@ def service_slow_requests(start_time: str, service: px.Service):
                         suffixes=['', '_x'])
     requests = requests[requests.latency_ms >= requests.service_p99]
     return requests[['time_', 'pod', 'latency_ms', 'http_req_method',
-                     'http_req_path', 'http_resp_status', 'remote_addr', 'remote_port',
+                     'http_req_path', 'http_req_body', 'http_resp_status', 'remote_addr', 'remote_port',
                      'http_resp_message', 'http_resp_body']].head(100)
 
 

--- a/pxl_scripts/px/service/service.pxl
+++ b/pxl_scripts/px/service/service.pxl
@@ -42,26 +42,25 @@ def inbound_let_timeseries(start_time: str, service: px.Service):
     df = df[df.service == service]
 
     df = df.groupby(['timestamp']).agg(
-        latency_quantiles=('latency_ms', px.quantiles),
+        latency_quantiles=('latency', px.quantiles),
         error_rate_per_window=('failure', px.mean),
-        throughput_total=('latency_ms', px.count),
+        throughput_total=('latency', px.count),
         bytes_total=('resp_size', px.sum)
     )
 
     # Format the result of LET aggregates into proper scalar formats and
     # time series.
-    window_size = window_s * 1.0
-    df.latency_p50 = px.pluck_float64(df.latency_quantiles, 'p50')
-    df.latency_p90 = px.pluck_float64(df.latency_quantiles, 'p90')
-    df.latency_p99 = px.pluck_float64(df.latency_quantiles, 'p99')
-    df.requests_per_s = df.throughput_total / window_size
-    df.errors_per_s = df.error_rate_per_window * df.requests_per_s
-    df.error_rate_pct = df.error_rate_per_window * 100
-    df.mbytes_per_s = df.bytes_total / (1024.0 * 1024.0 * window_size)
+    df.latency_p50 = px.DurationNanos(px.floor(px.pluck_float64(df.latency_quantiles, 'p50')))
+    df.latency_p90 = px.DurationNanos(px.floor(px.pluck_float64(df.latency_quantiles, 'p90')))
+    df.latency_p99 = px.DurationNanos(px.floor(px.pluck_float64(df.latency_quantiles, 'p99')))
+    df.request_throughput = df.throughput_total / window_ns
+    df.errors_per_ns = df.error_rate_per_window * df.request_throughput / px.DurationNanos(1)
+    df.error_rate = px.Percent(df.error_rate_per_window)
+    df.bytes_per_ns = df.bytes_total / window_ns
     df.time_ = df.timestamp
 
     return df[['time_', 'latency_p50', 'latency_p90', 'latency_p99',
-               'requests_per_s', 'errors_per_s', 'error_rate_pct', 'mbytes_per_s']]
+               'request_throughput', 'errors_per_ns', 'error_rate', 'bytes_per_ns']]
 
 
 def inbound_let_summary(start_time: str, service: px.Service):
@@ -98,11 +97,11 @@ def let_summary_helper(start_time: str):
     df = let_helper(start_time)
 
     quantiles_agg = df.groupby(['service', 'remote_addr']).agg(
-        latency_ms=('latency_ms', px.quantiles),
-        total_request_count=('latency_ms', px.count)
+        latency=('latency', px.quantiles),
+        total_request_count=('latency', px.count)
     )
 
-    quantiles_table = quantiles_agg[['service', 'remote_addr', 'latency_ms',
+    quantiles_table = quantiles_agg[['service', 'remote_addr', 'latency',
                                      'total_request_count']]
 
     range_agg = df.groupby(['service', 'remote_addr', 'timestamp']).agg(
@@ -121,29 +120,30 @@ def let_summary_helper(start_time: str):
                                          right_on=['service', 'remote_addr'],
                                          suffixes=['', '_x'])
 
-    joined_table.error_rate_pct = 100 * joined_table.error_rate
-    joined_table.requests_per_s = joined_table.requests_per_window / (1.0 * window_s)
+    joined_table.error_rate = px.Percent(joined_table.error_rate)
+    joined_table.request_throughput = joined_table.requests_per_window / window_ns
 
     joined_table.responder = df.service
     joined_table.requestor = px.pod_id_to_service_name(px.ip_to_pod_id(df.remote_addr))
 
-    return joined_table[['responder', 'requestor', 'remote_addr', 'latency_ms',
-                         'error_rate_pct', 'requests_per_s']]
+    return joined_table[['responder', 'requestor', 'remote_addr', 'latency',
+                         'error_rate', 'request_throughput']]
 
 
 def service_slow_requests(start_time: str, service: px.Service):
     df = let_helper(start_time)
     df = df[df.service == service]
     quantiles = df.groupby('service').agg(
-        latency_quantiles=('latency_ms', px.quantiles)
+        latency_quantiles=('latency', px.quantiles)
     )
     quantiles.service_p99 = px.pluck_float64(quantiles.latency_quantiles, 'p99')
     quantiles = quantiles.drop('latency_quantiles')
     requests = df.merge(quantiles, left_on='service', right_on='service', how='inner',
                         suffixes=['', '_x'])
-    requests = requests[requests.latency_ms >= requests.service_p99]
-    return requests[['time_', 'pod', 'latency_ms', 'http_req_method',
-                     'http_req_path', 'http_req_body', 'http_resp_status', 'remote_addr', 'remote_port',
+    requests = requests[requests.latency >= px.floor(requests.service_p99)]
+    return requests[['time_', 'pod', 'latency', 'http_req_method',
+                     'http_req_path', 'http_req_body', 'http_resp_status',
+                     'remote_addr', 'remote_port',
                      'http_resp_message', 'http_resp_body']].head(100)
 
 
@@ -158,11 +158,11 @@ def let_helper(start_time: str):
     df = px.DataFrame(table='http_events', start_time=start_time)
     df.service = df.ctx['service']
     df.pod = df.ctx['pod']
-    df.latency_ms = df.http_resp_latency_ns / 1.0E6
-    df = df[df['latency_ms'] < 10000.0]
-    df.timestamp = px.bin(df.time_, px.seconds(window_s))
+    df.latency = df.http_resp_latency_ns
+    df = df[df['latency'] < (10000 * ns_per_ms)]
+    df.timestamp = px.bin(df.time_, window_ns)
 
-    df.resp_size = px.length(df.http_resp_body)
+    df.resp_size = px.Bytes(px.length(df.http_resp_body))
     df.failure = df.http_resp_status >= 400
     filter_out_conds = ((df.http_req_path != '/health' or not filter_health_checks) and (
         df.http_req_path != '/readyz' or not filter_ready_checks)) and (

--- a/pxl_scripts/px/service/vis.json
+++ b/pxl_scripts/px/service/vis.json
@@ -45,13 +45,13 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "requests_per_s",
+            "value": "request_throughput",
             "mode": "MODE_LINE"
           }
         ],
         "title": "",
         "yAxis": {
-          "label": "requests per second"
+          "label": "request throughput"
         },
         "xAxis": null
       }
@@ -69,13 +69,13 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "errors_per_s",
+            "value": "errors_per_ns",
             "mode": "MODE_LINE"
           }
         ],
         "title": "",
         "yAxis": {
-          "label": "errors per second"
+          "label": "error rate"
         },
         "xAxis": null
       }
@@ -107,13 +107,13 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "Latency (ms)"
+          "label": "Latency"
         },
         "xAxis": null
       }
     },
     {
-      "name": "HTTP Response Size",
+      "name": "HTTP Response Data Throughput",
       "position": {
         "x": 0,
         "y": 3,
@@ -125,13 +125,13 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "mbytes_per_s",
+            "value": "bytes_per_ns",
             "mode": "MODE_LINE"
           }
         ],
         "title": "",
         "yAxis": {
-          "label": "MB / s"
+          "label": "Response data throughput"
         },
         "xAxis": null
       }

--- a/pxl_scripts/px/service_edge_stats/service_edge_stats.pxl
+++ b/pxl_scripts/px/service_edge_stats/service_edge_stats.pxl
@@ -77,7 +77,8 @@ def svc_edge_let(start: str, requesting_svc: px.Service,
     let_df = let_df[px.contains(let_df[src_col], requesting_svc)]
     let_df[dest_col] = let_df[k8s_object]
     let_df = let_df['time_', src_col, split_series_name, dest_col, 'latency_p50',
-                    'latency_p90', 'latency_p99', 'error_rate', 'rps', 'bytes_per_s']
+                    'latency_p90', 'latency_p99', 'error_rate',
+                    'request_throughput', 'bytes_per_ns']
     return let_df
 
 
@@ -155,10 +156,10 @@ def make_http_table(start: str):
     return df
 
 
-def format_events_table(df, latency_ns_col):
+def format_events_table(df, latency_col):
     """ Format data and add semantic columns in event tables
 
-    Unifies latency column to 'latency_ms', adds a binned
+    Unifies latency column to 'latency', adds a binned
     timestamp field to aggregate on, and adds the svc
     (k8s_object) as a semantic column.
 
@@ -166,13 +167,13 @@ def format_events_table(df, latency_ns_col):
 
     Args:
     @df: the input events table
-    @latency_ns_col: the name of the latency column in @df.
+    @latency_col: the name of the latency column in @df.
 
     Returns: formatted events DataFrame
     """
-    df.latency_ms = df[latency_ns_col] / 1.0E6
-    df = df[df['latency_ms'] < 10000.0]
-    df.timestamp = px.bin(df.time_, px.seconds(window_s))
+    df.latency = df[latency_col]
+    df = df[df['latency'] < (10000 * ns_per_ms)]
+    df.timestamp = px.bin(df.time_, window_ns)
     df[k8s_object] = df.ctx[k8s_object]
     df = df[df[k8s_object] != '']
     return df
@@ -212,7 +213,7 @@ def format_LET_aggs(df):
 
     Converts the result of aggregates on windows into well-formatted metrics that
     can be visualized. Latency quantile values need to be extracted from the
-    quantiles struct, and then error_rate, rps, and bytes_per_s are calculated as
+    quantiles struct, and then error_rate, request_throughput, and bytes_per_ns are calculated as
     a function of window size.
 
 
@@ -221,19 +222,17 @@ def format_LET_aggs(df):
 
     Args:
     @df: the input events table grouped into windows with aggregated
-        columns 'throughput_total', 'error_rate_per_window', and 'rps'
+        columns 'throughput_total', 'error_rate_per_window', and 'request_throughput'
 
     Returns: DataFrame with formatted LET metrics.
     """
-    window_size = window_s * 1.0
-
-    df.latency_p50 = px.pluck_float64(df.latency_quantiles, 'p50')
-    df.latency_p90 = px.pluck_float64(df.latency_quantiles, 'p90')
-    df.latency_p99 = px.pluck_float64(df.latency_quantiles, 'p99')
+    df.latency_p50 = px.DurationNanos(px.floor(px.pluck_float64(df.latency_quantiles, 'p50')))
+    df.latency_p90 = px.DurationNanos(px.floor(px.pluck_float64(df.latency_quantiles, 'p90')))
+    df.latency_p99 = px.DurationNanos(px.floor(px.pluck_float64(df.latency_quantiles, 'p99')))
     df['time_'] = df['timestamp']
-    df.rps = df.throughput_total / window_size
-    df.bytes_per_s = df.bytes_total / window_size
-    df.error_rate = df.error_rate_per_window * df.rps
+    df.request_throughput = df.throughput_total / window_ns
+    df.bytes_per_ns = df.bytes_total / window_ns
+    df.error_rate = df.error_rate_per_window * df.request_throughput / px.DurationNanos(1)
 
     return df
 
@@ -242,7 +241,7 @@ def calc_http_LET(df, groups):
     """ Calculates Latency, Error Rate, and Throughput on HTTP events.
 
     Calculates latency, error rate, and throughput aggregated over
-    @groups. Throughput is represented by two values: rps, and bytes_per_s.
+    @groups. Throughput is represented by two values: request_throughput, and bytes_per_ns.
 
     Args:
     @df: the input http_events table.
@@ -253,11 +252,12 @@ def calc_http_LET(df, groups):
     """
     # Aggregate values over the window.
     df = df.groupby(groups).agg(
-        latency_quantiles=('latency_ms', px.quantiles),
+        latency_quantiles=('latency', px.quantiles),
         error_rate_per_window=('failure', px.mean),
-        throughput_total=('latency_ms', px.count),
+        throughput_total=('latency', px.count),
         bytes_total=('resp_size', px.sum)
     )
+    df.bytes_total = px.Bytes(df.bytes_total)
 
     # Format the result of LET aggregates into proper scalar formats and
     # time series.
@@ -314,8 +314,8 @@ def summarize_LET(let_df, groups):
     """
 
     df = let_df.groupby(groups).agg(
-        rps=('rps', px.mean),
-        bytes_per_s=('bytes_per_s', px.mean),
+        request_throughput=('request_throughput', px.mean),
+        bytes_per_ns=('bytes_per_ns', px.mean),
         error_rate=('error_rate', px.mean),
     )
     return df

--- a/pxl_scripts/px/service_edge_stats/service_edge_stats.pxl
+++ b/pxl_scripts/px/service_edge_stats/service_edge_stats.pxl
@@ -19,8 +19,10 @@ import px
 # K8s object is the abstraction to group on.
 # Options are ['pod', 'service'].
 k8s_object = 'service'
-# Window in seconds within which to aggregate metrics.
-window_s = 10
+ns_per_ms = 1000 * 1000
+ns_per_s = 1000 * ns_per_ms
+# Window size to use on time_ column for bucketing.
+window_ns = px.DurationNanos(10 * ns_per_s)
 # Flag to filter out requests that come from an unresolvable IP.
 filter_unresolved_inbound = True
 # Flag to filter out health checks from the data.

--- a/pxl_scripts/px/service_edge_stats/vis.json
+++ b/pxl_scripts/px/service_edge_stats/vis.json
@@ -63,7 +63,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "P50 Latency (ms)"
+          "label": "P50 Latency"
         },
         "xAxis": null
       }
@@ -89,7 +89,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "P90 Latency (ms)"
+          "label": "P90 Latency"
         },
         "xAxis": null
       }
@@ -107,7 +107,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "rps",
+            "value": "request_throughput",
             "series": "k8s",
             "stackBySeries": false,
             "mode": "MODE_LINE"
@@ -115,7 +115,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "RPS"
+          "label": "request throughput"
         },
         "xAxis": null
       }
@@ -141,7 +141,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "Error Rate (%)"
+          "label": "Error Rate"
         },
         "xAxis": null
       }

--- a/pxl_scripts/px/service_memory_usage/usage.pxl
+++ b/pxl_scripts/px/service_memory_usage/usage.pxl
@@ -20,34 +20,31 @@ match_name = ''
 # the specified k8s objects in the cluster.
 #
 t1 = px.DataFrame(table='process_stats', start_time='-1m')
-bytes_per_mb = 1024.0 * 1024.0
-t1.vsize_mb = t1.vsize_bytes / bytes_per_mb
-t1.rss_bytes_mb = t1.rss_bytes / bytes_per_mb
 t1.timestamp = px.bin(t1.time_, px.seconds(10))
 t1[k8s_object] = t1.ctx[k8s_object]
 
 t1 = t1[px.contains(t1[k8s_object], match_name)]
 
 upid_aggop = t1.groupby(['upid', k8s_object, 'timestamp']).agg(
-    vsize_mb=('vsize_mb', px.mean),
-    rss_bytes_mb=('rss_bytes_mb', px.mean),
+    vsize=('vsize_bytes', px.mean),
+    rss=('rss_bytes', px.mean),
 )
 
 # For this aggregate, we sum up the values as we've already calculated the average/usage
 # for the upids already, just need to do it for the entire service.
 aggop = upid_aggop.groupby([k8s_object, 'timestamp']).agg(
-    vsize_mb=('vsize_mb', px.sum),
-    rss_bytes_mb=('rss_bytes_mb', px.sum),
+    vsize=('vsize', px.sum),
+    rss=('rss', px.sum),
 )
 
 # Format column names.
-aggop['Virtual Memory (mb)'] = aggop.vsize_mb
-aggop['Average Memory (mb)'] = aggop.rss_bytes_mb
+aggop['Virtual Memory'] = aggop.vsize
+aggop['Average Memory'] = aggop.rss
 keep_columns = aggop[[
     k8s_object,
     'timestamp',
-    'Virtual Memory (mb)',
-    'Average Memory (mb)'
+    'Virtual Memory',
+    'Average Memory'
 ]]
 
 px.display(keep_columns)

--- a/pxl_scripts/px/service_stats/service_stats.pxl
+++ b/pxl_scripts/px/service_stats/service_stats.pxl
@@ -41,7 +41,7 @@ dest_col = 'responder'
 # visualization spec.
 split_series_name = 'k8s'
 # The bin size to use for the latency histogram.
-latency_bin_size_ms = 50
+latency_bin_size_ns = px.DurationNanos(50 * ns_per_ms)
 # ----------------------------------------------------------------
 
 
@@ -65,7 +65,8 @@ def svc_let(start: str, svc: px.Service):
     # Format and organize resulting columns.
     let_df[split_series_name] = let_df[k8s_object]
     let_df = let_df[['time_', split_series_name, 'latency_p50',
-                     'latency_p90', 'latency_p99', 'error_rate', 'rps', 'bytes_per_s']]
+                     'latency_p90', 'latency_p99', 'error_rate',
+                     'request_throughput', 'bytes_per_ns']]
     return let_df
 
 
@@ -96,9 +97,9 @@ def latency_histogram(start: str, svc: px.Service):
     """
     df = make_http_table(start)
     matching_df = df[px.contains(df[k8s_object], svc)]
-    matching_df.request_latency_ms = px.bin(matching_df.http_resp_latency_ns / (1000 * 1000),
-                                            latency_bin_size_ms)
-    return matching_df.groupby('request_latency_ms').agg(count=('time_', px.count))
+    matching_df.request_latency = px.bin(matching_df.http_resp_latency_ns,
+                                         latency_bin_size_ns)
+    return matching_df.groupby('request_latency').agg(count=('time_', px.count))
 
 
 def outgoing_edges(start: str, svc: px.Service):
@@ -206,10 +207,10 @@ def let_per_edge(start: str):
     return edge_let_df
 
 
-def format_events_table(df, latency_ns_col):
+def format_events_table(df, latency_col):
     """ Format data and add semantic columns in event tables
 
-    Unifies latency column to 'latency_ms', adds a binned
+    Unifies latency column to 'latency', adds a binned
     timestamp field to aggregate on, and adds the svc
     (k8s_object) as a semantic column.
 
@@ -217,13 +218,13 @@ def format_events_table(df, latency_ns_col):
 
     Args:
     @df: the input events table
-    @latency_ns_col: the name of the latency column in @df.
+    @latency_col: the name of the latency column in @df.
 
     Returns: formatted events DataFrame
     """
-    df.latency_ms = df[latency_ns_col] / 1.0E6
-    df = df[df['latency_ms'] < 10000.0]
-    df.timestamp = px.bin(df.time_, px.seconds(window_s))
+    df.latency = df[latency_col]
+    df = df[df['latency'] < (10000 * ns_per_ms)]
+    df.timestamp = px.bin(df.time_, window_ns)
     df[k8s_object] = df.ctx[k8s_object]
     df = df[df[k8s_object] != '']
     return df
@@ -248,7 +249,7 @@ def format_http_table(df, filter_health_checks, filter_ready_checks,
     Returns: formatted HTTP events DataFrame.
     """
     df = format_events_table(df, 'http_resp_latency_ns')
-    df.resp_size = px.length(df.http_resp_body)
+    df.resp_size = px.Bytes(px.length(df.http_resp_body))
     df.failure = df.http_resp_status >= 400
     filter_out_conds = ((df.http_req_path != '/health' or not filter_health_checks) and (
         df.http_req_path != '/readyz' or not filter_ready_checks)) and (
@@ -263,7 +264,7 @@ def format_LET_aggs(df):
 
     Converts the result of aggregates on windows into well-formatted metrics that
     can be visualized. Latency quantile values need to be extracted from the
-    quantiles struct, and then error_rate, rps, and bytes_per_s are calculated as
+    quantiles struct, and then error_rate, request_throughput, and bytes_per_ns are calculated as
     a function of window size.
 
 
@@ -272,19 +273,17 @@ def format_LET_aggs(df):
 
     Args:
     @df: the input events table grouped into windows with aggregated
-        columns 'throughput_total', 'error_rate_per_window', and 'rps'
+        columns 'throughput_total', 'error_rate_per_window', and 'request_throughput'
 
     Returns: DataFrame with formatted LET metrics.
     """
-    window_size = window_s * 1.0
-
-    df.latency_p50 = px.pluck_float64(df.latency_quantiles, 'p50')
-    df.latency_p90 = px.pluck_float64(df.latency_quantiles, 'p90')
-    df.latency_p99 = px.pluck_float64(df.latency_quantiles, 'p99')
+    df.latency_p50 = px.DurationNanos(px.floor(px.pluck_float64(df.latency_quantiles, 'p50')))
+    df.latency_p90 = px.DurationNanos(px.floor(px.pluck_float64(df.latency_quantiles, 'p90')))
+    df.latency_p99 = px.DurationNanos(px.floor(px.pluck_float64(df.latency_quantiles, 'p99')))
     df['time_'] = df['timestamp']
-    df.rps = df.throughput_total / window_size
-    df.bytes_per_s = df.bytes_total / window_size
-    df.error_rate = df.error_rate_per_window * df.rps
+    df.request_throughput = df.throughput_total / window_ns
+    df.bytes_per_ns = df.bytes_total / window_ns
+    df.error_rate = df.error_rate_per_window * df.request_throughput / px.DurationNanos(1)
 
     return df
 
@@ -293,7 +292,7 @@ def calc_http_LET(df, groups):
     """ Calculates Latency, Error Rate, and Throughput on HTTP events.
 
     Calculates latency, error rate, and throughput aggregated over
-    @groups. Throughput is represented by two values: rps, and bytes_per_s.
+    @groups. Throughput is represented by two values: request_throughput, and bytes_per_ns.
 
     Args:
     @df: the input http_events table.
@@ -304,9 +303,9 @@ def calc_http_LET(df, groups):
     """
     # Aggregate values over the window.
     df = df.groupby(groups).agg(
-        latency_quantiles=('latency_ms', px.quantiles),
+        latency_quantiles=('latency', px.quantiles),
         error_rate_per_window=('failure', px.mean),
-        throughput_total=('latency_ms', px.count),
+        throughput_total=('latency', px.count),
         bytes_total=('resp_size', px.sum)
     )
 
@@ -346,8 +345,8 @@ def summarize_LET(let_df, groups):
     """
 
     df = let_df.groupby(groups).agg(
-        rps=('rps', px.mean),
-        bytes_per_s=('bytes_per_s', px.mean),
+        request_throughput=('request_throughput', px.mean),
+        bytes_per_ns=('bytes_per_ns', px.mean),
         error_rate=('error_rate', px.mean),
     )
     return df

--- a/pxl_scripts/px/service_stats/service_stats.pxl
+++ b/pxl_scripts/px/service_stats/service_stats.pxl
@@ -82,7 +82,7 @@ def http_code_histogram(start: str, svc: px.Service):
     """
     df = make_http_table(start)
     matching_df = df[px.contains(df[k8s_object], svc)]
-    return matching_df.groupby(['http_resp_status']).agg(count=('time_', px.count))
+    return matching_df.groupby(['http_resp_status']).agg(count=('http_resp_latency_ns', px.count))
 
 
 def latency_histogram(start: str, svc: px.Service):
@@ -97,9 +97,9 @@ def latency_histogram(start: str, svc: px.Service):
     """
     df = make_http_table(start)
     matching_df = df[px.contains(df[k8s_object], svc)]
-    matching_df.request_latency = px.bin(matching_df.http_resp_latency_ns,
-                                         latency_bin_size_ns)
-    return matching_df.groupby('request_latency').agg(count=('time_', px.count))
+    matching_df.request_latency = px.DurationNanos(px.bin(matching_df.http_resp_latency_ns,
+                                                          latency_bin_size_ns))
+    return matching_df.groupby('request_latency').agg(count=('http_resp_status', px.count))
 
 
 def outgoing_edges(start: str, svc: px.Service):

--- a/pxl_scripts/px/service_stats/service_stats.pxl
+++ b/pxl_scripts/px/service_stats/service_stats.pxl
@@ -20,8 +20,10 @@ import px
 # K8s object is the abstraction to group on.
 # Options are ['pod', 'service'].
 k8s_object = 'service'
-# Window in seconds within which to aggregate metrics.
-window_s = 10
+ns_per_ms = 1000 * 1000
+ns_per_s = 1000 * ns_per_ms
+# Window size to use on time_ column for bucketing.
+window_ns = px.DurationNanos(10 * ns_per_s)
 # Flag to filter out requests that come from an unresolvable IP.
 filter_unresolved_inbound = True
 # Flag to filter out health checks from the data.

--- a/pxl_scripts/px/service_stats/vis.json
+++ b/pxl_scripts/px/service_stats/vis.json
@@ -53,7 +53,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "P50 Latency (ms)"
+          "label": "P50 Latency"
         },
         "xAxis": null
       }
@@ -79,7 +79,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "P90 Latency (ms)"
+          "label": "P90 Latency"
         },
         "xAxis": null
       }
@@ -97,7 +97,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "rps",
+            "value": "request_throughput",
             "series": "k8s",
             "stackBySeries": false,
             "mode": "MODE_LINE"
@@ -105,7 +105,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "RPS"
+          "label": "Request throughput"
         },
         "xAxis": null
       }
@@ -131,7 +131,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "Error Rate (%)"
+          "label": "Error Rate"
         },
         "xAxis": null
       }
@@ -190,13 +190,13 @@
       "displaySpec": {
         "@type": "pixielabs.ai/pl.vispb.HistogramChart",
         "histogram": {
-          "value": "request_latency_ms",
+          "value": "request_latency",
           "prebinCount": "count",
           "maxbins": 10,
           "minstep": 50.0
         },
         "xAxis": {
-          "label": "Request Latency (ms)"
+          "label": "Request Latency"
         },
         "yAxis": {
           "label": "# of requests"

--- a/pxl_scripts/px/service_stats/vis.json
+++ b/pxl_scripts/px/service_stats/vis.json
@@ -193,7 +193,7 @@
           "value": "request_latency",
           "prebinCount": "count",
           "maxbins": 10,
-          "minstep": 50.0
+          "minstep": 50000000
         },
         "xAxis": {
           "label": "Request Latency"

--- a/pxl_scripts/px/services/services.pxl
+++ b/pxl_scripts/px/services/services.pxl
@@ -8,8 +8,10 @@
 
 import px
 
-# Window in seconds within which to aggregate metrics.
-window_s = 10
+ns_per_ms = 1000 * 1000
+ns_per_s = 1000 * ns_per_ms
+# Window size to use on time_ column for bucketing.
+window_ns = px.DurationNanos(10 * ns_per_s)
 # Flag to filter out requests that come from an unresolvable IP.
 filter_unresolved_inbound = True
 # Flag to filter out health checks from the data.

--- a/pxl_scripts/px/services/services.pxl
+++ b/pxl_scripts/px/services/services.pxl
@@ -51,9 +51,9 @@ def inbound_service_let(start_time: str, namespace: px.Namespace):
 
     df = inbound_service_let_helper(start_time, namespace)
     df = df.groupby(['timestamp', 'service']).agg(
-        latency_quantiles=('latency_ms', px.quantiles),
+        latency_quantiles=('latency', px.quantiles),
         error_rate=('failure', px.mean),
-        throughput_total=('latency_ms', px.count),
+        throughput_total=('latency', px.count),
         inbound_bytes_total=('req_size', px.sum),
         outbound_bytes_total=('resp_size', px.sum)
     )
@@ -62,16 +62,15 @@ def inbound_service_let(start_time: str, namespace: px.Namespace):
     df.latency_p90 = px.pluck_float64(df.latency_quantiles, 'p90')
     df.latency_p99 = px.pluck_float64(df.latency_quantiles, 'p99')
 
-    window_size = 1.0 * window_s
-    df.requests_per_s = df.throughput_total / window_size
-    df.inbound_bytes_per_s = df.inbound_bytes_total / window_size
-    df.outbound_bytes_per_s = df.outbound_bytes_total / window_size
-    df.error_rate_pct = df.error_rate * 100 / window_size
+    df.request_throughput = df.throughput_total / window_ns
+    df.inbound_throughput = df.inbound_bytes_total / window_ns
+    df.outbound_throughput = df.outbound_bytes_total / window_ns
+    df.error_rate = px.Percent(df.error_rate)
     df.time_ = df.timestamp
 
     return df[['time_', 'service', 'latency_p50', 'latency_p90',
-               'latency_p99', 'requests_per_s', 'error_rate_pct',
-               'inbound_bytes_per_s', 'outbound_bytes_per_s']]
+               'latency_p99', 'request_throughput', 'error_rate',
+               'inbound_throughput', 'outbound_throughput']]
 
 
 def inbound_let_summary(start_time: str, namespace: px.Namespace):
@@ -87,35 +86,34 @@ def inbound_let_summary(start_time: str, namespace: px.Namespace):
     df.responder = df.service
     df.requestor = px.pod_id_to_service_name(px.ip_to_pod_id(df.remote_addr))
 
-    per_s_df = df.groupby(['timestamp', 'requestor', 'responder']).agg(
-        throughput_total=('latency_ms', px.count),
+    per_ns_df = df.groupby(['timestamp', 'requestor', 'responder']).agg(
+        throughput_total=('latency', px.count),
         inbound_bytes_total=('req_size', px.sum),
         outbound_bytes_total=('resp_size', px.sum)
     )
 
-    window_size = 1.0 * window_s
-    per_s_df.requests_per_s = per_s_df.throughput_total / window_size
-    per_s_df.inbound_bytes_per_s = per_s_df.inbound_bytes_total / window_size
-    per_s_df.outbound_bytes_per_s = per_s_df.inbound_bytes_total / window_size
+    per_ns_df.request_throughput = per_ns_df.throughput_total / window_ns
+    per_ns_df.inbound_throughput = per_ns_df.inbound_bytes_total / window_ns
+    per_ns_df.outbound_throughput = per_ns_df.inbound_bytes_total / window_ns
 
-    per_s_df = per_s_df.groupby(['requestor', 'responder']).agg(
-        requests_per_s=('requests_per_s', px.mean),
-        inbound_bytes_per_s=('inbound_bytes_per_s', px.mean),
-        outbound_bytes_per_s=('outbound_bytes_per_s', px.mean)
+    per_ns_df = per_ns_df.groupby(['requestor', 'responder']).agg(
+        request_throughput=('request_throughput', px.mean),
+        inbound_throughput=('inbound_throughput', px.mean),
+        outbound_throughput=('outbound_throughput', px.mean)
     )
 
     quantiles_df = df.groupby(['requestor', 'responder']).agg(
-        latency_ms=('latency_ms', px.quantiles)
+        latency=('latency', px.quantiles)
         error_rate=('failure', px.mean),
     )
 
-    quantiles_df.error_rate_pct = quantiles_df.error_rate * 100 / window_size
+    quantiles_df.error_rate = px.Percent(quantiles_df.error_rate)
 
-    joined = per_s_df.merge(quantiles_df, left_on=['requestor', 'responder'],
-                            right_on=['requestor', 'responder'], how='inner',
-                            suffixes=['', '_x'])
-    return joined[['requestor', 'responder', 'latency_ms', 'requests_per_s', 'error_rate_pct',
-                   'inbound_bytes_per_s', 'outbound_bytes_per_s']]
+    joined = per_ns_df.merge(quantiles_df, left_on=['requestor', 'responder'],
+                             right_on=['requestor', 'responder'], how='inner',
+                             suffixes=['', '_x'])
+    return joined[['requestor', 'responder', 'latency', 'request_throughput', 'error_rate',
+                   'inbound_throughput', 'outbound_throughput']]
 
 
 def inbound_let_service_graph(start_time: str, namespace: px.Namespace):
@@ -129,9 +127,9 @@ def inbound_let_service_graph(start_time: str, namespace: px.Namespace):
     '''
     df = inbound_service_let_helper(start_time, namespace)
     df = df.groupby(['timestamp', 'service', 'remote_addr', 'pod']).agg(
-        latency_quantiles=('latency_ms', px.quantiles),
+        latency_quantiles=('latency', px.quantiles),
         error_rate=('failure', px.mean),
-        throughput_total=('latency_ms', px.count),
+        throughput_total=('latency', px.count),
         inbound_bytes_total=('req_size', px.sum),
         outbound_bytes_total=('resp_size', px.sum)
     )
@@ -147,21 +145,20 @@ def inbound_let_service_graph(start_time: str, namespace: px.Namespace):
     df.responder_service = df.service
     df.requestor_service = px.pod_id_to_service_name(df.requestor_pod_id)
 
-    window_size = 1.0 * window_s
-    df.requests_per_s = df.throughput_total / window_size
-    df.inbound_bytes_per_s = df.inbound_bytes_total / window_size
-    df.outbound_bytes_per_s = df.outbound_bytes_total / window_size
-    df.error_rate_pct = df.error_rate * 100 / window_size
+    df.request_throughput = df.throughput_total / window_ns
+    df.inbound_throughput = df.inbound_bytes_total / window_ns
+    df.outbound_throughput = df.outbound_bytes_total / window_ns
+    df.error_rate = px.Percent(df.error_rate)
 
     return df.groupby(['responder_pod', 'requestor_pod', 'responder_service',
                        'requestor_service']).agg(
         latency_p50=('latency_p50', px.mean),
         latency_p90=('latency_p90', px.mean),
         latency_p99=('latency_p99', px.mean),
-        requests_per_s=('requests_per_s', px.mean),
-        error_rate_pct=('error_rate_pct', px.mean),
-        inbound_bytes_per_s=('inbound_bytes_per_s', px.mean),
-        outbound_bytes_per_s=('outbound_bytes_per_s', px.mean),
+        request_throughput=('request_throughput', px.mean),
+        error_rate=('error_rate', px.mean),
+        inbound_throughput=('inbound_throughput', px.mean),
+        outbound_throughput=('outbound_throughput', px.mean),
         throughput_total=('throughput_total', px.sum)
     )
 
@@ -179,12 +176,12 @@ def inbound_service_let_helper(start_time: str, namespace: px.Namespace):
     df.service = df.ctx['service']
     df.pod = df.ctx['pod_name']
     df = df[df.ctx['namespace'] == namespace and df.service != '']
-    df.latency_ms = df.http_resp_latency_ns / 1.0E6
-    df = df[df['latency_ms'] < 10000.0]
-    df.timestamp = px.bin(df.time_, px.seconds(window_s))
+    df.latency = df.http_resp_latency_ns
+    df = df[df['latency'] < (10000 * ns_per_ms)]
+    df.timestamp = px.bin(df.time_, window_ns)
 
-    df.req_size = px.length(df.http_req_body)
-    df.resp_size = px.length(df.http_resp_body)
+    df.req_size = px.Bytes(px.length(df.http_req_body))
+    df.resp_size = px.Bytes(px.length(df.http_resp_body))
     df.failure = df.http_resp_status >= 400
     filter_out_conds = ((df.http_req_path != '/health' or not filter_health_checks) and (
         df.http_req_path != '/readyz' or not filter_ready_checks)) and (

--- a/pxl_scripts/px/services/vis.json
+++ b/pxl_scripts/px/services/vis.json
@@ -70,7 +70,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "requests_per_s",
+            "value": "request_throughput",
             "mode": "MODE_LINE",
             "series": "service",
             "stackBySeries": false
@@ -96,7 +96,7 @@
         "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
         "timeseries": [
           {
-            "value": "error_rate_pct",
+            "value": "error_rate",
             "mode": "MODE_LINE",
             "series": "service",
             "stackBySeries": false
@@ -110,7 +110,7 @@
       }
     },
     {
-      "name": "HTTP P50 Latency (ms)",
+      "name": "HTTP P50 Latency",
       "position": {
         "x": 0,
         "y": 3,
@@ -130,13 +130,13 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "Mean latency (ms)"
+          "label": "Mean latency"
         },
         "xAxis": null
       }
     },
     {
-      "name": "HTTP P90 Latency (ms)",
+      "name": "HTTP P90 Latency",
       "position": {
         "x": 4,
         "y": 3,
@@ -156,13 +156,13 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "Mean latency (ms)"
+          "label": "Mean latency"
         },
         "xAxis": null
       }
     },
     {
-      "name": "HTTP P99 Latency (ms)",
+      "name": "HTTP P99 Latency",
       "position": {
         "x": 8,
         "y": 3,
@@ -182,7 +182,7 @@
         ],
         "title": "",
         "yAxis": {
-          "label": "Mean latency (ms)"
+          "label": "Mean latency"
         },
         "xAxis": null
       }
@@ -217,10 +217,10 @@
         "p50Column": "latency_p50",
         "p90Column": "latency_p90",
         "p99Column": "latency_p99",
-        "errorRateColumn": "error_rate_pct",
-        "requestsPerSecondColumn": "requests_per_s",
-        "inboundBytesPerSecondColumn": "inbound_bytes_per_s",
-        "outboundBytesPerSecondColumn": "outbound_bytes_per_s",
+        "errorRateColumn": "error_rate",
+        "requestsPerSecondColumn": "request_throughput",
+        "inboundBytesPerSecondColumn": "inbound_throughput",
+        "outboundBytesPerSecondColumn": "outbound_throughput",
         "totalRequestCountColumn": "throughput_total"
       }
     },

--- a/pxl_scripts/px/slow_http_requests/slow_http_requests.pxl
+++ b/pxl_scripts/px/slow_http_requests/slow_http_requests.pxl
@@ -10,27 +10,29 @@ filter_health_checks = True
 # Flag to filter out ready checks from the data.
 filter_ready_checks = True
 
+ns_per_ms = 1000 * 1000
+
 
 def namespace_slow_requests(start_time: str, namespace: px.Namespace):
     df = px.DataFrame(table='http_events', start_time=start_time)
     df.service = df.ctx['service']
     df.pod = df.ctx['pod_name']
     df = df[df.ctx['namespace'] == namespace and df.service != '']
-    df.latency_ms = df.http_resp_latency_ns / 1.0E6
+    df.latency = df.http_resp_latency_ns
     filter_out_conds = (((df.http_req_path != '/health' or not filter_health_checks) and (
         df.http_req_path != '/readyz' or not filter_ready_checks)) and (
         df['remote_addr'] != '-' or not filter_unresolved_inbound)) and (
-        df.latency_ms > 100.0)
+        df.latency > 100 * ns_per_ms)
 
     df = df[filter_out_conds]
     quantiles = df.groupby('service').agg(
-        latency_quantiles=('latency_ms', px.quantiles)
+        latency_quantiles=('latency', px.quantiles)
     )
     quantiles.service_p99 = px.pluck_float64(quantiles.latency_quantiles, 'p99')
     quantiles = quantiles.drop('latency_quantiles')
     requests = df.merge(quantiles, left_on='service', right_on='service', how='inner',
                         suffixes=['', '_x'])
-    requests = requests[requests.latency_ms >= requests.service_p99]
-    return requests[['time_', 'service', 'pod', 'latency_ms', 'http_req_method',
+    requests = requests[requests.latency >= px.floor(requests.service_p99)]
+    return requests[['time_', 'service', 'pod', 'latency', 'http_req_method',
                      'http_req_path', 'http_resp_status', 'remote_addr', 'remote_port',
                      'http_resp_message', 'http_resp_body']].head(1000)


### PR DESCRIPTION
Adds support for ST_BYTES, ST_THROUGHPUT_PER_NS, ST_THROUGHPUT_BYTES_PER_NS, and ST_DURATION_NS_QUANTILES, in the scripts.

With these changes I tested the following scripts:
- px/cluster
- http_data
- http_data_filtered
- http_post_requests
- http_request_stats
- jvm_data
- jvm_stats
- largest_http_request
- mysql_data
- mysql_stats
- namespaces
- namespace
- nodes
- node
- pid_memory_usage
- pixie_quality_metrics
- pods
- pod
- pod_edge_stats
- pod_lifetime_resource
- pod_memory_usage
- service
- service_edge_stats
- service_memory_usage
- service_stats
- slow_http_requests
- psql_data
- psql_stats:w
