### PR TITLE
Update px/tcp_drops edgeWeight/Color/Hover column

### DIFF
--- a/pxl_scripts/px/tcp_drops/vis.json
+++ b/pxl_scripts/px/tcp_drops/vis.json
@@ -25,15 +25,15 @@
           "fromColumn": "src",
           "toColumn": "dst"
         },
-        "edgeWeightColumn": "retransmits",
-        "edgeColorColumn": "retransmits",
+        "edgeWeightColumn": "drops",
+        "edgeColorColumn": "drops",
         "edgeLength": 300,
         "edgeThresholds": {
           "mediumThreshold": 5,
           "highThreshold": 50
         },
         "edgeHoverInfo": [
-          "retransmits"
+          "drops"
         ]
       }
     }


### PR DESCRIPTION
tcp_drops was modified from tcp_retransmits, and the edge weight/color/hover column wasn't updated to use the drops column.