### PR TITLE
Actually remove latency filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 
 # The decrypted service account file.
 gcs-sa.json
+.python-version

--- a/pxl_scripts/px/cluster/cluster.pxl
+++ b/pxl_scripts/px/cluster/cluster.pxl
@@ -210,7 +210,6 @@ def inbound_service_let_helper(start_time: str):
     df.pod = df.ctx['pod_name']
     df = df[df.service != '']
     df.latency = df.http_resp_latency_ns
-    df = df[df['latency'] < (10000 * ns_per_ms)]
     df.timestamp = px.bin(df.time_, window_ns)
     df.req_size = px.Bytes(px.length(df.http_req_body))
     df.resp_size = px.Bytes(px.length(df.http_resp_body))

--- a/pxl_scripts/px/cql_stats/cql_stats.pxl
+++ b/pxl_scripts/px/cql_stats/cql_stats.pxl
@@ -149,7 +149,7 @@ def format_events_table(df, latency_col):
     Returns: formatted events DataFrame
     """
     df.latency = df[latency_col]
-    df = df[df.latency < (10000 * ns_per_ms)]
+
     df.timestamp = px.bin(df.time_, window_ns)
     df[k8s_object] = df.ctx[k8s_object]
     df = df[df[k8s_object] != '']

--- a/pxl_scripts/px/mysql_stats/mysql_stats.pxl
+++ b/pxl_scripts/px/mysql_stats/mysql_stats.pxl
@@ -157,7 +157,7 @@ def format_events_table(df, latency_col):
     Returns: formatted events DataFrame
     """
     df.latency = df[latency_col]
-    df = df[df.latency < (10000 * ns_per_ms)]
+
     df.timestamp = px.bin(df.time_, window_ns)
     df[k8s_object] = df.ctx[k8s_object]
     df = df[df[k8s_object] != '']

--- a/pxl_scripts/px/namespace/namespace.pxl
+++ b/pxl_scripts/px/namespace/namespace.pxl
@@ -142,7 +142,7 @@ def inbound_service_let_helper(start_time: str, namespace: px.Namespace):
     df.pod = df.ctx['pod_name']
     df = df[df.ctx['namespace'] == namespace and df.service != '']
     df.latency = df.http_resp_latency_ns
-    df = df[df['latency'] < (10000 * ns_per_ms)]
+
     df.timestamp = px.bin(df.time_, window_ns)
 
     df.req_size = px.Bytes(px.length(df.http_req_body))

--- a/pxl_scripts/px/pod/pod.pxl
+++ b/pxl_scripts/px/pod/pod.pxl
@@ -273,7 +273,7 @@ def let_helper(start_time: str):
     df = px.DataFrame(table='http_events', start_time=start_time)
     df.pod = df.ctx['pod']
     df.latency = df.http_resp_latency_ns
-    df = df[df['latency'] < (10000 * ns_per_ms)]
+
     df.timestamp = px.bin(df.time_, window_ns)
 
     df.resp_size = px.length(df.http_resp_body)

--- a/pxl_scripts/px/pods/pods.pxl
+++ b/pxl_scripts/px/pods/pods.pxl
@@ -188,7 +188,7 @@ def inbound_let_helper(start_time: str, namespace: px.Namespace):
     df.pod = df.ctx['pod']
     df = df[df.pod != '']
     df.latency = df.http_resp_latency_ns
-    df = df[df['latency'] < (10000 * ns_per_ms)]
+
     df.timestamp = px.bin(df.time_, window_ns)
 
     df.resp_size = px.Bytes(px.length(df.http_resp_body))

--- a/pxl_scripts/px/psql_stats/pgsql_stats.pxl
+++ b/pxl_scripts/px/psql_stats/pgsql_stats.pxl
@@ -151,7 +151,7 @@ def format_events_table(df, latency_col):
     Returns: formatted events DataFrame
     '''
     df.latency = df[latency_col]
-    df = df[df['latency'] < (10000 * ns_per_ms)]
+
     df.timestamp = px.bin(df.time_, window_ns)
     df[k8s_object] = df.ctx[k8s_object]
     df = df[df[k8s_object] != '']

--- a/pxl_scripts/px/service/service.pxl
+++ b/pxl_scripts/px/service/service.pxl
@@ -139,7 +139,7 @@ def let_helper(start_time: str):
     df.service = df.ctx['service']
     df.pod = df.ctx['pod']
     df.latency = df.http_resp_latency_ns
-    df = df[df['latency'] < (10000 * ns_per_ms)]
+
     df.timestamp = px.bin(df.time_, window_ns)
 
     df.resp_size = px.Bytes(px.length(df.http_resp_body))

--- a/pxl_scripts/px/service_edge_stats/service_edge_stats.pxl
+++ b/pxl_scripts/px/service_edge_stats/service_edge_stats.pxl
@@ -172,7 +172,7 @@ def format_events_table(df, latency_col):
     Returns: formatted events DataFrame
     """
     df.latency = df[latency_col]
-    df = df[df['latency'] < (10000 * ns_per_ms)]
+
     df.timestamp = px.bin(df.time_, window_ns)
     df[k8s_object] = df.ctx[k8s_object]
     df = df[df[k8s_object] != '']

--- a/pxl_scripts/px/service_stats/service_stats.pxl
+++ b/pxl_scripts/px/service_stats/service_stats.pxl
@@ -223,7 +223,7 @@ def format_events_table(df, latency_col):
     Returns: formatted events DataFrame
     """
     df.latency = df[latency_col]
-    df = df[df['latency'] < (10000 * ns_per_ms)]
+
     df.timestamp = px.bin(df.time_, window_ns)
     df[k8s_object] = df.ctx[k8s_object]
     df = df[df[k8s_object] != '']


### PR DESCRIPTION
Noticed upon closer inspection that #155 actually only removed a single latency filter but left many around. This diff does what that diff promised. Should entirely be removing the latency filter line.