### PR TITLE
Revise redis data script so it's visible to public

### DIFF
--- a/pxl_scripts/README.md
+++ b/pxl_scripts/README.md
@@ -3,56 +3,57 @@
 # PXL Scripts Overview
 
 Pixie open sources all of its scripts, which serve as examples of scripting in the PxL language. To learn more about PxL, take a look at our [documentation](https://docs.pixielabs.ai/pxl).
-- px/[agent_status](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/agent_status): This script gets the status of all the pixie agents (PEMs/Collectors) running.
-- px/[cluster](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/cluster): This view lists the namespaces and the node that are available on the current cluster.
-- px/[cql_data](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/cql_data): Shows a sample of CQL (Cassandra) requests in the cluster.
-- px/[cql_stats](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/cql_stats): This live view calculates the latency, error rate, and throughput of a pod's CQL (Cassandra) requests.
-- px/[demo_script](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/demo_script): Shows a sample of HTTP requests in the cluster with a very terse display format.
-- px/[dns_data](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/dns_data): Show a sample of DNS traffic in the cluster.
-- px/[dns_flow_graph](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/dns_flow_graph): Overview of DNS requests in the cluster, with latency stats.
-- px/[dns_query_summary](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/dns_query_summary): Overview of DNS queries from pods in a namespace, grouped by the name being resolved and the rates of success.
-- px/[funcs](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/funcs): Gets a list all of the funcs available in Pixie.
-- px/[http_data](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/http_data): Shows most recent HTTP messages in the cluster.
-- px/[http_data_filtered](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/http_data_filtered): Show a sample of HTTP requests in the Cluster filtered by service, pod & req-path.
-- px/[http_post_requests](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/http_post_requests): Show a sample of HTTP requests in the Cluster that have method POST.
-- px/[http_request_stats](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/http_request_stats): HTTP request statistics aggregated by Service
-- px/[jvm_data](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/jvm_data): JVM stats for Java processes running on the cluster
-- px/[jvm_stats](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/jvm_stats): Returns the JVM Stats per Pod. You can filter this by node.
-- px/[largest_http_request](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/largest_http_request): Calculates the largest HTTP Request according to the passed in filter value.
-- px/[most_http_data](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/most_http_data): Finds the endpoint on a specific Pod that passes the most HTTP Data. Optionally, you can uncomment a line to see a table summarizing data per service, endpoint pair.
-- px/[mysql_data](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/mysql_data): Shows most recent MySQL messages in the cluster.
-- px/[mysql_stats](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/mysql_stats): This live view calculates the latency, error rate, and throughput of a pod's MySQL requests.
-- px/[namespace](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/namespace): This view gives a top-level summary of the pods and services in a given namespace, as well as a service map.
-- px/[namespaces](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/namespaces): This view lists the namespaces on the current cluster and their pod and service counts. It also lists the high-level resource consumption by namespace.
-- px/[net_flow_graph](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/net_flow_graph): The mapping of all outgoing connections for the specified k8s pods in the namespace.
-- px/[network_stats](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/network_stats): Get network stats time series
-- px/[node](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/node): This view summarizes the process and network stats for a given input node in a cluster. It computes CPU, memory consumption, as well as network traffic statistics. It also displays a list of pods that were on that node during the time window.
-- px/[nodes](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/nodes): This view summarizes the process and network stats for each node in a cluster. It computes CPU, memory consumption, as well as network traffic statistics, per node. It also displays a list of pods that were on each node during the time window.
-- px/[pid_memory_usage](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/pid_memory_usage): Get the Virtual memory usage and average memory for all processes in the k8s cluster.
-- px/[pixie_quality_metrics](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/pixie_quality_metrics): Metrics that sample Pixie's collector data.
-- px/[pod](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/pod): Overview of a specific Pod monitored by Pixie with its high level application metrics (latency, error-rate & rps) and resource usage (cpu, writes, reads).
-- px/[pod_edge_stats](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/pod_edge_stats): Gets pod latency, error rate and throughput according to another service. Edit the requestor filter to the name of the incoming service you want to filter by.
+- px/[agent_status](pxl_scripts/README.md/px/agent_status): This script gets the status of all the pixie agents (PEMs/Collectors) running.
+- px/[cluster](pxl_scripts/README.md/px/cluster): This view lists the namespaces and the node that are available on the current cluster.
+- px/[cql_data](pxl_scripts/README.md/px/cql_data): Shows a sample of CQL (Cassandra) requests in the cluster.
+- px/[cql_stats](pxl_scripts/README.md/px/cql_stats): This live view calculates the latency, error rate, and throughput of a pod's CQL (Cassandra) requests.
+- px/[demo_script](pxl_scripts/README.md/px/demo_script): Shows a sample of HTTP requests in the cluster with a very terse display format.
+- px/[dns_data](pxl_scripts/README.md/px/dns_data): Show a sample of DNS traffic in the cluster.
+- px/[dns_flow_graph](pxl_scripts/README.md/px/dns_flow_graph): Overview of DNS requests in the cluster, with latency stats.
+- px/[dns_query_summary](pxl_scripts/README.md/px/dns_query_summary): Overview of DNS queries from pods in a namespace, grouped by the name being resolved and the rates of success.
+- px/[funcs](pxl_scripts/README.md/px/funcs): Gets a list all of the funcs available in Pixie.
+- px/[http_data](pxl_scripts/README.md/px/http_data): Shows most recent HTTP messages in the cluster.
+- px/[http_data_filtered](pxl_scripts/README.md/px/http_data_filtered): Show a sample of HTTP requests in the Cluster filtered by service, pod & req-path.
+- px/[http_post_requests](pxl_scripts/README.md/px/http_post_requests): Show a sample of HTTP requests in the Cluster that have method POST.
+- px/[http_request_stats](pxl_scripts/README.md/px/http_request_stats): HTTP request statistics aggregated by Service
+- px/[jvm_data](pxl_scripts/README.md/px/jvm_data): JVM stats for Java processes running on the cluster
+- px/[jvm_stats](pxl_scripts/README.md/px/jvm_stats): Returns the JVM Stats per Pod. You can filter this by node.
+- px/[largest_http_request](pxl_scripts/README.md/px/largest_http_request): Calculates the largest HTTP Request according to the passed in filter value.
+- px/[most_http_data](pxl_scripts/README.md/px/most_http_data): Finds the endpoint on a specific Pod that passes the most HTTP Data. Optionally, you can uncomment a line to see a table summarizing data per service, endpoint pair.
+- px/[mysql_data](pxl_scripts/README.md/px/mysql_data): Shows most recent MySQL messages in the cluster.
+- px/[mysql_stats](pxl_scripts/README.md/px/mysql_stats): This live view calculates the latency, error rate, and throughput of a pod's MySQL requests.
+- px/[namespace](pxl_scripts/README.md/px/namespace): This view gives a top-level summary of the pods and services in a given namespace, as well as a service map.
+- px/[namespaces](pxl_scripts/README.md/px/namespaces): This view lists the namespaces on the current cluster and their pod and service counts. It also lists the high-level resource consumption by namespace.
+- px/[net_flow_graph](pxl_scripts/README.md/px/net_flow_graph): The mapping of all outgoing connections for the specified k8s pods in the namespace.
+- px/[network_stats](pxl_scripts/README.md/px/network_stats): Get network stats time series
+- px/[node](pxl_scripts/README.md/px/node): This view summarizes the process and network stats for a given input node in a cluster. It computes CPU, memory consumption, as well as network traffic statistics. It also displays a list of pods that were on that node during the time window.
+- px/[nodes](pxl_scripts/README.md/px/nodes): This view summarizes the process and network stats for each node in a cluster. It computes CPU, memory consumption, as well as network traffic statistics, per node. It also displays a list of pods that were on each node during the time window.
+- px/[pid_memory_usage](pxl_scripts/README.md/px/pid_memory_usage): Get the Virtual memory usage and average memory for all processes in the k8s cluster.
+- px/[pixie_quality_metrics](pxl_scripts/README.md/px/pixie_quality_metrics): Metrics that sample Pixie's collector data.
+- px/[pod](pxl_scripts/README.md/px/pod): Overview of a specific Pod monitored by Pixie with its high level application metrics (latency, error-rate & rps) and resource usage (cpu, writes, reads).
+- px/[pod_edge_stats](pxl_scripts/README.md/px/pod_edge_stats): Gets pod latency, error rate and throughput according to another service. Edit the requestor filter to the name of the incoming service you want to filter by.
 Visualize these in three separate time series charts.
-- px/[pod_lifetime_resource](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/pod_lifetime_resource): Total resource usage of a pod over it's lifetime.
-- px/[pod_memory_usage](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/pod_memory_usage): Get the Virtual memory usage and average memory for all processes in the k8s cluster.
-- px/[pods](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/pods): List of Pods monitored by Pixie in a given Namespace with their high level application metrics (latency, error-rate & rps) and resource usage (cpu, writes, reads).
-- px/[postgres_data](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/postgres_data): Shows most recent PGSQL (Postgres) messages in the cluster.
-- px/[psql_data](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/psql_data): Shows a sample of PostgreSQL request in the cluster.
-- px/[psql_stats](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/psql_stats): This live view calculates the latency, error rate, and throughput of a pod's PostgreSQL requests.
-- px/[schemas](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/schemas): Get all the table schemas available in the system
-- px/[service](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/service): This script gets an overview of an individual service, summarizing its request statistics.
-- px/[service_edge_stats](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/service_edge_stats): Gets service latency, error rate and throughput according to another service. Edit the requestor filter to the name of the incoming service you want to filter by.
+- px/[pod_lifetime_resource](pxl_scripts/README.md/px/pod_lifetime_resource): Total resource usage of a pod over it's lifetime.
+- px/[pod_memory_usage](pxl_scripts/README.md/px/pod_memory_usage): Get the Virtual memory usage and average memory for all processes in the k8s cluster.
+- px/[pods](pxl_scripts/README.md/px/pods): List of Pods monitored by Pixie in a given Namespace with their high level application metrics (latency, error-rate & rps) and resource usage (cpu, writes, reads).
+- px/[postgres_data](pxl_scripts/README.md/px/postgres_data): Shows most recent PGSQL (Postgres) messages in the cluster.
+- px/[psql_data](pxl_scripts/README.md/px/psql_data): Shows a sample of PostgreSQL request in the cluster.
+- px/[psql_stats](pxl_scripts/README.md/px/psql_stats): This live view calculates the latency, error rate, and throughput of a pod's PostgreSQL requests.
+- px/[redis_data](pxl_scripts/README.md/px/redis_data): Shows a sample of Redis messages in the cluster. WARNING: Redis tracing is a beta feature. This script is for demonstration purposes only.
+- px/[schemas](pxl_scripts/README.md/px/schemas): Get all the table schemas available in the system
+- px/[service](pxl_scripts/README.md/px/service): This script gets an overview of an individual service, summarizing its request statistics.
+- px/[service_edge_stats](pxl_scripts/README.md/px/service_edge_stats): Gets service latency, error rate and throughput according to another service. Edit the requestor filter to the name of the incoming service you want to filter by.
 Visualize these in three separate time series charts.
-- px/[service_memory_usage](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/service_memory_usage): Get the Virtual memory usage and average memory for all services in the k8s cluster.
-- px/[service_stats](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/service_stats): Gets service latency, error rate and throughput. Visualize them in three separate time series charts.
-- px/[services](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/services): This script gets an overview of the services in a namespace, summarizing their request statistics.
-- px/[slow_http_requests](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/slow_http_requests): This view shows a sample of slow requests by service.
-- px/[tcp_drops](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/tcp_drops): Shows TCP drop counts in the cluster.
-- px/[tcp_retransmits](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/tcp_retransmits): Shows TCP retransmission counts in the cluster.
-- px/[tracepoint_status](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/tracepoint_status): Returns information about tracepoints running on the cluster.
-- px/[upids](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/upids): Shows a list of UPIDs running in a given namespace.
-- sotw/[dns_external_fqdn_list](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/sotw/dns_external_fqdn_list): Lists external, fully qualified domain names (FQDNs) from all DNS traffic on the cluster for a specified amount of time.
-- sotw/[dns_queries_filtered](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/sotw/dns_queries_filtered): Lists all DNS queries filtered by a specific query name.
+- px/[service_memory_usage](pxl_scripts/README.md/px/service_memory_usage): Get the Virtual memory usage and average memory for all services in the k8s cluster.
+- px/[service_stats](pxl_scripts/README.md/px/service_stats): Gets service latency, error rate and throughput. Visualize them in three separate time series charts.
+- px/[services](pxl_scripts/README.md/px/services): This script gets an overview of the services in a namespace, summarizing their request statistics.
+- px/[slow_http_requests](pxl_scripts/README.md/px/slow_http_requests): This view shows a sample of slow requests by service.
+- px/[tcp_drops](pxl_scripts/README.md/px/tcp_drops): Shows TCP drop counts in the cluster.
+- px/[tcp_retransmits](pxl_scripts/README.md/px/tcp_retransmits): Shows TCP retransmission counts in the cluster.
+- px/[tracepoint_status](pxl_scripts/README.md/px/tracepoint_status): Returns information about tracepoints running on the cluster.
+- px/[upids](pxl_scripts/README.md/px/upids): Shows a list of UPIDs running in a given namespace.
+- sotw/[dns_external_fqdn_list](pxl_scripts/README.md/sotw/dns_external_fqdn_list): Lists external, fully qualified domain names (FQDNs) from all DNS traffic on the cluster for a specified amount of time.
+- sotw/[dns_queries_filtered](pxl_scripts/README.md/sotw/dns_queries_filtered): Lists all DNS queries filtered by a specific query name.
 
 
 ## Contributing

--- a/pxl_scripts/README.md
+++ b/pxl_scripts/README.md
@@ -3,57 +3,57 @@
 # PXL Scripts Overview
 
 Pixie open sources all of its scripts, which serve as examples of scripting in the PxL language. To learn more about PxL, take a look at our [documentation](https://docs.pixielabs.ai/pxl).
-- px/[agent_status](pxl_scripts/README.md/px/agent_status): This script gets the status of all the pixie agents (PEMs/Collectors) running.
-- px/[cluster](pxl_scripts/README.md/px/cluster): This view lists the namespaces and the node that are available on the current cluster.
-- px/[cql_data](pxl_scripts/README.md/px/cql_data): Shows a sample of CQL (Cassandra) requests in the cluster.
-- px/[cql_stats](pxl_scripts/README.md/px/cql_stats): This live view calculates the latency, error rate, and throughput of a pod's CQL (Cassandra) requests.
-- px/[demo_script](pxl_scripts/README.md/px/demo_script): Shows a sample of HTTP requests in the cluster with a very terse display format.
-- px/[dns_data](pxl_scripts/README.md/px/dns_data): Show a sample of DNS traffic in the cluster.
-- px/[dns_flow_graph](pxl_scripts/README.md/px/dns_flow_graph): Overview of DNS requests in the cluster, with latency stats.
-- px/[dns_query_summary](pxl_scripts/README.md/px/dns_query_summary): Overview of DNS queries from pods in a namespace, grouped by the name being resolved and the rates of success.
-- px/[funcs](pxl_scripts/README.md/px/funcs): Gets a list all of the funcs available in Pixie.
-- px/[http_data](pxl_scripts/README.md/px/http_data): Shows most recent HTTP messages in the cluster.
-- px/[http_data_filtered](pxl_scripts/README.md/px/http_data_filtered): Show a sample of HTTP requests in the Cluster filtered by service, pod & req-path.
-- px/[http_post_requests](pxl_scripts/README.md/px/http_post_requests): Show a sample of HTTP requests in the Cluster that have method POST.
-- px/[http_request_stats](pxl_scripts/README.md/px/http_request_stats): HTTP request statistics aggregated by Service
-- px/[jvm_data](pxl_scripts/README.md/px/jvm_data): JVM stats for Java processes running on the cluster
-- px/[jvm_stats](pxl_scripts/README.md/px/jvm_stats): Returns the JVM Stats per Pod. You can filter this by node.
-- px/[largest_http_request](pxl_scripts/README.md/px/largest_http_request): Calculates the largest HTTP Request according to the passed in filter value.
-- px/[most_http_data](pxl_scripts/README.md/px/most_http_data): Finds the endpoint on a specific Pod that passes the most HTTP Data. Optionally, you can uncomment a line to see a table summarizing data per service, endpoint pair.
-- px/[mysql_data](pxl_scripts/README.md/px/mysql_data): Shows most recent MySQL messages in the cluster.
-- px/[mysql_stats](pxl_scripts/README.md/px/mysql_stats): This live view calculates the latency, error rate, and throughput of a pod's MySQL requests.
-- px/[namespace](pxl_scripts/README.md/px/namespace): This view gives a top-level summary of the pods and services in a given namespace, as well as a service map.
-- px/[namespaces](pxl_scripts/README.md/px/namespaces): This view lists the namespaces on the current cluster and their pod and service counts. It also lists the high-level resource consumption by namespace.
-- px/[net_flow_graph](pxl_scripts/README.md/px/net_flow_graph): The mapping of all outgoing connections for the specified k8s pods in the namespace.
-- px/[network_stats](pxl_scripts/README.md/px/network_stats): Get network stats time series
-- px/[node](pxl_scripts/README.md/px/node): This view summarizes the process and network stats for a given input node in a cluster. It computes CPU, memory consumption, as well as network traffic statistics. It also displays a list of pods that were on that node during the time window.
-- px/[nodes](pxl_scripts/README.md/px/nodes): This view summarizes the process and network stats for each node in a cluster. It computes CPU, memory consumption, as well as network traffic statistics, per node. It also displays a list of pods that were on each node during the time window.
-- px/[pid_memory_usage](pxl_scripts/README.md/px/pid_memory_usage): Get the Virtual memory usage and average memory for all processes in the k8s cluster.
-- px/[pixie_quality_metrics](pxl_scripts/README.md/px/pixie_quality_metrics): Metrics that sample Pixie's collector data.
-- px/[pod](pxl_scripts/README.md/px/pod): Overview of a specific Pod monitored by Pixie with its high level application metrics (latency, error-rate & rps) and resource usage (cpu, writes, reads).
-- px/[pod_edge_stats](pxl_scripts/README.md/px/pod_edge_stats): Gets pod latency, error rate and throughput according to another service. Edit the requestor filter to the name of the incoming service you want to filter by.
+- px/[agent_status](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/agent_status): This script gets the status of all the pixie agents (PEMs/Collectors) running.
+- px/[cluster](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/cluster): This view lists the namespaces and the node that are available on the current cluster.
+- px/[cql_data](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/cql_data): Shows a sample of CQL (Cassandra) requests in the cluster.
+- px/[cql_stats](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/cql_stats): This live view calculates the latency, error rate, and throughput of a pod's CQL (Cassandra) requests.
+- px/[demo_script](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/demo_script): Shows a sample of HTTP requests in the cluster with a very terse display format.
+- px/[dns_data](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/dns_data): Show a sample of DNS traffic in the cluster.
+- px/[dns_flow_graph](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/dns_flow_graph): Overview of DNS requests in the cluster, with latency stats.
+- px/[dns_query_summary](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/dns_query_summary): Overview of DNS queries from pods in a namespace, grouped by the name being resolved and the rates of success.
+- px/[funcs](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/funcs): Gets a list all of the funcs available in Pixie.
+- px/[http_data](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/http_data): Shows most recent HTTP messages in the cluster.
+- px/[http_data_filtered](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/http_data_filtered): Show a sample of HTTP requests in the Cluster filtered by service, pod & req-path.
+- px/[http_post_requests](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/http_post_requests): Show a sample of HTTP requests in the Cluster that have method POST.
+- px/[http_request_stats](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/http_request_stats): HTTP request statistics aggregated by Service
+- px/[jvm_data](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/jvm_data): JVM stats for Java processes running on the cluster
+- px/[jvm_stats](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/jvm_stats): Returns the JVM Stats per Pod. You can filter this by node.
+- px/[largest_http_request](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/largest_http_request): Calculates the largest HTTP Request according to the passed in filter value.
+- px/[most_http_data](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/most_http_data): Finds the endpoint on a specific Pod that passes the most HTTP Data. Optionally, you can uncomment a line to see a table summarizing data per service, endpoint pair.
+- px/[mysql_data](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/mysql_data): Shows most recent MySQL messages in the cluster.
+- px/[mysql_stats](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/mysql_stats): This live view calculates the latency, error rate, and throughput of a pod's MySQL requests.
+- px/[namespace](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/namespace): This view gives a top-level summary of the pods and services in a given namespace, as well as a service map.
+- px/[namespaces](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/namespaces): This view lists the namespaces on the current cluster and their pod and service counts. It also lists the high-level resource consumption by namespace.
+- px/[net_flow_graph](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/net_flow_graph): The mapping of all outgoing connections for the specified k8s pods in the namespace.
+- px/[network_stats](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/network_stats): Get network stats time series
+- px/[node](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/node): This view summarizes the process and network stats for a given input node in a cluster. It computes CPU, memory consumption, as well as network traffic statistics. It also displays a list of pods that were on that node during the time window.
+- px/[nodes](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/nodes): This view summarizes the process and network stats for each node in a cluster. It computes CPU, memory consumption, as well as network traffic statistics, per node. It also displays a list of pods that were on each node during the time window.
+- px/[pid_memory_usage](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/pid_memory_usage): Get the Virtual memory usage and average memory for all processes in the k8s cluster.
+- px/[pixie_quality_metrics](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/pixie_quality_metrics): Metrics that sample Pixie's collector data.
+- px/[pod](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/pod): Overview of a specific Pod monitored by Pixie with its high level application metrics (latency, error-rate & rps) and resource usage (cpu, writes, reads).
+- px/[pod_edge_stats](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/pod_edge_stats): Gets pod latency, error rate and throughput according to another service. Edit the requestor filter to the name of the incoming service you want to filter by.
 Visualize these in three separate time series charts.
-- px/[pod_lifetime_resource](pxl_scripts/README.md/px/pod_lifetime_resource): Total resource usage of a pod over it's lifetime.
-- px/[pod_memory_usage](pxl_scripts/README.md/px/pod_memory_usage): Get the Virtual memory usage and average memory for all processes in the k8s cluster.
-- px/[pods](pxl_scripts/README.md/px/pods): List of Pods monitored by Pixie in a given Namespace with their high level application metrics (latency, error-rate & rps) and resource usage (cpu, writes, reads).
-- px/[postgres_data](pxl_scripts/README.md/px/postgres_data): Shows most recent PGSQL (Postgres) messages in the cluster.
-- px/[psql_data](pxl_scripts/README.md/px/psql_data): Shows a sample of PostgreSQL request in the cluster.
-- px/[psql_stats](pxl_scripts/README.md/px/psql_stats): This live view calculates the latency, error rate, and throughput of a pod's PostgreSQL requests.
-- px/[redis_data](pxl_scripts/README.md/px/redis_data): Shows a sample of Redis messages in the cluster. WARNING: Redis tracing is a beta feature. This script is for demonstration purposes only.
-- px/[schemas](pxl_scripts/README.md/px/schemas): Get all the table schemas available in the system
-- px/[service](pxl_scripts/README.md/px/service): This script gets an overview of an individual service, summarizing its request statistics.
-- px/[service_edge_stats](pxl_scripts/README.md/px/service_edge_stats): Gets service latency, error rate and throughput according to another service. Edit the requestor filter to the name of the incoming service you want to filter by.
+- px/[pod_lifetime_resource](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/pod_lifetime_resource): Total resource usage of a pod over it's lifetime.
+- px/[pod_memory_usage](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/pod_memory_usage): Get the Virtual memory usage and average memory for all processes in the k8s cluster.
+- px/[pods](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/pods): List of Pods monitored by Pixie in a given Namespace with their high level application metrics (latency, error-rate & rps) and resource usage (cpu, writes, reads).
+- px/[postgres_data](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/postgres_data): Shows most recent PGSQL (Postgres) messages in the cluster.
+- px/[psql_data](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/psql_data): Shows a sample of PostgreSQL request in the cluster.
+- px/[psql_stats](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/psql_stats): This live view calculates the latency, error rate, and throughput of a pod's PostgreSQL requests.
+- px/[redis_data](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/redis_data): Shows a sample of Redis messages in the cluster. WARNING: Redis tracing is a beta feature. This script is for demonstration purposes only.
+- px/[schemas](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/schemas): Get all the table schemas available in the system
+- px/[service](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/service): This script gets an overview of an individual service, summarizing its request statistics.
+- px/[service_edge_stats](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/service_edge_stats): Gets service latency, error rate and throughput according to another service. Edit the requestor filter to the name of the incoming service you want to filter by.
 Visualize these in three separate time series charts.
-- px/[service_memory_usage](pxl_scripts/README.md/px/service_memory_usage): Get the Virtual memory usage and average memory for all services in the k8s cluster.
-- px/[service_stats](pxl_scripts/README.md/px/service_stats): Gets service latency, error rate and throughput. Visualize them in three separate time series charts.
-- px/[services](pxl_scripts/README.md/px/services): This script gets an overview of the services in a namespace, summarizing their request statistics.
-- px/[slow_http_requests](pxl_scripts/README.md/px/slow_http_requests): This view shows a sample of slow requests by service.
-- px/[tcp_drops](pxl_scripts/README.md/px/tcp_drops): Shows TCP drop counts in the cluster.
-- px/[tcp_retransmits](pxl_scripts/README.md/px/tcp_retransmits): Shows TCP retransmission counts in the cluster.
-- px/[tracepoint_status](pxl_scripts/README.md/px/tracepoint_status): Returns information about tracepoints running on the cluster.
-- px/[upids](pxl_scripts/README.md/px/upids): Shows a list of UPIDs running in a given namespace.
-- sotw/[dns_external_fqdn_list](pxl_scripts/README.md/sotw/dns_external_fqdn_list): Lists external, fully qualified domain names (FQDNs) from all DNS traffic on the cluster for a specified amount of time.
-- sotw/[dns_queries_filtered](pxl_scripts/README.md/sotw/dns_queries_filtered): Lists all DNS queries filtered by a specific query name.
+- px/[service_memory_usage](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/service_memory_usage): Get the Virtual memory usage and average memory for all services in the k8s cluster.
+- px/[service_stats](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/service_stats): Gets service latency, error rate and throughput. Visualize them in three separate time series charts.
+- px/[services](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/services): This script gets an overview of the services in a namespace, summarizing their request statistics.
+- px/[slow_http_requests](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/slow_http_requests): This view shows a sample of slow requests by service.
+- px/[tcp_drops](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/tcp_drops): Shows TCP drop counts in the cluster.
+- px/[tcp_retransmits](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/tcp_retransmits): Shows TCP retransmission counts in the cluster.
+- px/[tracepoint_status](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/tracepoint_status): Returns information about tracepoints running on the cluster.
+- px/[upids](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/upids): Shows a list of UPIDs running in a given namespace.
+- sotw/[dns_external_fqdn_list](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/sotw/dns_external_fqdn_list): Lists external, fully qualified domain names (FQDNs) from all DNS traffic on the cluster for a specified amount of time.
+- sotw/[dns_queries_filtered](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/sotw/dns_queries_filtered): Lists all DNS queries filtered by a specific query name.
 
 
 ## Contributing

--- a/pxl_scripts/px/redis_data/manifest.yaml
+++ b/pxl_scripts/px/redis_data/manifest.yaml
@@ -1,6 +1,5 @@
 ---
 short: Redis RPC messages
 long: >
-  Traces Redis RPC request and response messages.
-  WARNING: Redis tracing is a beta feature. Details may subject to further changes.
-org_name: pixielabs.ai
+  Shows a sample of Redis messages in the cluster.
+  WARNING: Redis tracing is a beta feature. This script is for demonstration purposes only.

--- a/pxl_scripts/px/redis_data/trace.pxl
+++ b/pxl_scripts/px/redis_data/trace.pxl
@@ -10,7 +10,7 @@ import px
 
 
 def redis_data(start: str, num_head: int):
-    # redis_events.beta is a beta table, may subject to changes.
+    # redis_events.beta is a beta table, which is subject to change.
     df = px.DataFrame(table='redis_events.beta', start_time=start)
 
     # Replace UPID with pod.

--- a/pxl_scripts/px/redis_data/vis.json
+++ b/pxl_scripts/px/redis_data/vis.json
@@ -3,7 +3,7 @@
     {
       "name": "start",
       "type": "PX_STRING",
-      "description": "The start time of the window in time units before now.",
+      "description": "The relative start time of the window. Current time is assumed to be now.",
       "defaultValue": "-5m"
     },
     {


### PR DESCRIPTION
Note removing org name makes this public.
The redis_table.beta naming change was released already, so this diff is now safe to merge.