### PR TITLE
Update PxL script Vis Specs to use required arguments.

### DIFF
--- a/pxl_scripts/README.md
+++ b/pxl_scripts/README.md
@@ -40,8 +40,8 @@ Visualize these in three separate time series charts.
 - px/[psql_data](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/psql_data): Shows a sample of PostgreSQL request in the cluster.
 - px/[psql_stats](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/psql_stats): This live view calculates the latency, error rate, and throughput of a pod's PostgreSQL requests.
 - px/[redis_data](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/redis_data): Shows a sample of Redis messages in the cluster. WARNING: Redis tracing is a beta feature. This script is for demonstration purposes only.
-- px/[redis_stats](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/redis_stats): This live view calculates the latency, error rate, and throughput of a pod's Redis requests.
 - px/[redis_flow_graph](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/redis_flow_graph): Graph of Redis messages in the cluster, with latency stats.
+- px/[redis_stats](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/redis_stats): This live view calculates the latency, error rate, and throughput of a pod's Redis requests.
 - px/[schemas](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/schemas): Get all the table schemas available in the system
 - px/[service](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/service): This script gets an overview of an individual service, summarizing its request statistics.
 - px/[service_edge_stats](https://github.com/pixie-labs/pixie/tree/main/pxl_scripts/px/service_edge_stats): Gets service latency, error rate and throughput according to another service. Edit the requestor filter to the name of the incoming service you want to filter by.

--- a/pxl_scripts/px/dns_query_summary/vis.json
+++ b/pxl_scripts/px/dns_query_summary/vis.json
@@ -9,8 +9,7 @@
     {
       "name": "namespace",
       "type": "PX_STRING",
-      "description": "The namespace to query.",
-      "defaultValue": "kube-system"
+      "description": "The namespace to query."
     },
     {
       "name": "pod_filter",

--- a/pxl_scripts/px/jvm_stats/vis.json
+++ b/pxl_scripts/px/jvm_stats/vis.json
@@ -9,7 +9,7 @@
     {
       "name": "node_name",
       "type": "PX_STRING",
-      "description": "The full/partial hostname to fitler by",
+      "description": "The full/partial hostname to filter by",
       "defaultValue": ""
     },
     {

--- a/pxl_scripts/px/namespace/vis.json
+++ b/pxl_scripts/px/namespace/vis.json
@@ -9,8 +9,7 @@
     {
       "name": "namespace",
       "type": "PX_NAMESPACE",
-      "description": "The name of the namespace.",
-      "defaultValue": "default"
+      "description": "The name of the namespace."
     }
   ],
   "widgets": [

--- a/pxl_scripts/px/net_flow_graph/vis.json
+++ b/pxl_scripts/px/net_flow_graph/vis.json
@@ -3,8 +3,7 @@
     {
       "name": "namespace",
       "type": "PX_NAMESPACE",
-      "description": "The namespace to filter on",
-      "defaultValue": "pl"
+      "description": "The namespace to filter on"
     },
     {
       "name": "start",

--- a/pxl_scripts/px/node/vis.json
+++ b/pxl_scripts/px/node/vis.json
@@ -9,8 +9,7 @@
     {
       "name": "node",
       "type": "PX_NODE",
-      "description": "The node name to filter on",
-      "defaultValue": ""
+      "description": "The node name to filter on"
     },
     {
       "name": "groupby",

--- a/pxl_scripts/px/pod/vis.json
+++ b/pxl_scripts/px/pod/vis.json
@@ -9,8 +9,7 @@
     {
       "name": "pod",
       "type": "PX_POD",
-      "description": "The pod name to filter on. Format: <ns>/<pod_name>",
-      "defaultValue": ""
+      "description": "The pod name to filter on. Format: <ns>/<pod_name>"
     }
   ],
   "globalFuncs": [

--- a/pxl_scripts/px/pods/vis.json
+++ b/pxl_scripts/px/pods/vis.json
@@ -9,8 +9,7 @@
     {
       "name": "namespace",
       "type": "PX_NAMESPACE",
-      "description": "The namespace to filter on",
-      "defaultValue": "default"
+      "description": "The namespace to filter on"
     }
   ],
   "globalFuncs": [

--- a/pxl_scripts/px/redis_flow_graph/vis.json
+++ b/pxl_scripts/px/redis_flow_graph/vis.json
@@ -9,8 +9,7 @@
     {
       "name": "namespace",
       "type": "PX_NAMESPACE",
-      "description": "The namespace to filter on.",
-      "defaultValue": "default"
+      "description": "The namespace to filter on."
     },
     {
       "name": "from_entity_filter",

--- a/pxl_scripts/px/service/vis.json
+++ b/pxl_scripts/px/service/vis.json
@@ -9,8 +9,7 @@
     {
       "name": "service",
       "type": "PX_SERVICE",
-      "description": "The name of the service to get stats for. Format: ns/svc_name",
-      "defaultValue": ""
+      "description": "The name of the service to get stats for. Format: ns/svc_name"
     }
   ],
   "globalFuncs": [

--- a/pxl_scripts/px/services/vis.json
+++ b/pxl_scripts/px/services/vis.json
@@ -9,8 +9,7 @@
     {
       "name": "namespace",
       "type": "PX_NAMESPACE",
-      "description": "The name of the namespace to get stats for.",
-      "defaultValue": "default"
+      "description": "The name of the namespace to get stats for."
     }
   ],
   "globalFuncs": [

--- a/pxl_scripts/px/slow_http_requests/vis.json
+++ b/pxl_scripts/px/slow_http_requests/vis.json
@@ -9,9 +9,7 @@
     {
       "name": "namespace",
       "type": "PX_NAMESPACE",
-      "description": "The name of the namespace to get stats for.",
-      "defaultValue": "default"
-    }
+      "description": "The name of the namespace to get stats for."    }
   ],
   "widgets": [
     {

--- a/pxl_scripts/sotw/dns_queries_filtered/vis.json
+++ b/pxl_scripts/sotw/dns_queries_filtered/vis.json
@@ -9,8 +9,7 @@
     {
       "name": "query_name_filter",
       "type": "PX_STRING",
-      "description": "The partial query name used to filter the DNS requests by.",
-      "defaultValue": "your.domain.name"
+      "description": "The partial query name used to filter the DNS requests by (e.g. your.domain.name)."
     }
   ],
   "globalFuncs": [


### PR DESCRIPTION
This PR should cause no visible changes. Instead, it is preparation for @NickLanam's planned UI changes that will alert users to the fact that some scripts have required arguments without which no Live View data will appear:
- Required args will be denoted with an asterisk next to the argument name.
- An error message when the user tries to run a script missing required argument values.

**Vis Spec Arguments:**
- To make a Vis Spec's argument **required**, omit the `defaultValue` field. To run the script, a value must be provided in the Live UI / CLI / API. 
- To make a Vis Spec's argument **optional**, provide a `defaultValue` field containing a string or empty string. An empty string means it's not pre-filled argument, but it's optional anyway. 