### PR TITLE
Adding endpoint clustering based beta scripts.

### DIFF
--- a/pxl_scripts/Makefile
+++ b/pxl_scripts/Makefile
@@ -1,6 +1,6 @@
 PIXIE_CLI := px
 # Update dir name here if you want to add a new directory.
-dirs := px sotw
+dirs := px sotw pxbeta
 script_files := $(foreach dir,$(dirs),$(wildcard $(dir)/**/*))
 BUNDLE := gs://pixie-prod-artifacts/script-bundles/bundle-oss.json
 EXECUTABLES = $(PIXIE_CLI) gsutil

--- a/pxl_scripts/pxbeta/service_endpoint/manifest.yaml
+++ b/pxl_scripts/pxbeta/service_endpoint/manifest.yaml
@@ -1,0 +1,4 @@
+---
+short: Endpoint Overview
+long: >
+  This script gets an overview of an individual endpoint for an individual service, summarizing its request statistics.

--- a/pxl_scripts/pxbeta/service_endpoint/service_endpoint.pxl
+++ b/pxl_scripts/pxbeta/service_endpoint/service_endpoint.pxl
@@ -1,0 +1,97 @@
+# Copyright (c) Pixie Labs, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License")
+
+''' Endpoint Overview
+
+ This script gets an overview of an individual endpoint on an individual service, summarizing its request statistics.
+'''
+
+import px
+
+ns_per_ms = 1000 * 1000
+ns_per_s = 1000 * ns_per_ms
+# Window size to use on time_ column for bucketing.
+window_ns = px.DurationNanos(10 * ns_per_s)
+# Flag to filter out requests that come from an unresolvable IP.
+filter_unresolved_inbound = False
+# Flag to filter out health checks from the data.
+filter_health_checks = False
+# Flag to filter out ready checks from the data.
+filter_ready_checks = False
+
+
+def endpoint_let_timeseries(start_time: str, service: px.Service, endpoint: str):
+    ''' Compute the let as a timeseries for requests received by `service` at `endpoint`.
+
+    Args:
+    @start_time: The timestamp of data to start at.
+    @service: The name of the service to filter on.
+    @endpoint: The endpoint to filter on.
+
+    '''
+    df = let_helper(start_time, service)
+    df = df[px._match_endpoint(df.http_req_path, endpoint)]
+
+    df = df.groupby(['timestamp']).agg(
+        latency_quantiles=('latency', px.quantiles),
+        error_rate_per_window=('failure', px.mean),
+        throughput_total=('latency', px.count),
+        bytes_total=('resp_size', px.sum)
+    )
+
+    # Format the result of LET aggregates into proper scalar formats and
+    # time series.
+    df.latency_p50 = px.DurationNanos(px.floor(px.pluck_float64(df.latency_quantiles, 'p50')))
+    df.latency_p90 = px.DurationNanos(px.floor(px.pluck_float64(df.latency_quantiles, 'p90')))
+    df.latency_p99 = px.DurationNanos(px.floor(px.pluck_float64(df.latency_quantiles, 'p99')))
+    df.request_throughput = df.throughput_total / window_ns
+    df.errors_per_ns = df.error_rate_per_window * df.request_throughput / px.DurationNanos(1)
+    df.error_rate = px.Percent(df.error_rate_per_window)
+    df.bytes_per_ns = df.bytes_total / window_ns
+    df.time_ = df.timestamp
+
+    return df[['time_', 'latency_p50', 'latency_p90', 'latency_p99',
+               'request_throughput', 'errors_per_ns', 'error_rate', 'bytes_per_ns']]
+
+
+def endpoint_slow_requests(start_time: str, service: px.Service, endpoint: str):
+    df = let_helper(start_time, service)
+    df = df[px._match_endpoint(df.http_req_path, endpoint)]
+    quantiles = df.groupby('service').agg(
+        latency_quantiles=('latency', px.quantiles)
+    )
+    quantiles.service_p99 = px.pluck_float64(quantiles.latency_quantiles, 'p99')
+    quantiles = quantiles.drop('latency_quantiles')
+    requests = df.merge(quantiles, left_on='service', right_on='service', how='inner',
+                        suffixes=['', '_x'])
+    requests = requests[requests.latency >= px.floor(requests.service_p99)]
+    return requests[['time_', 'pod', 'latency', 'http_req_method',
+                     'http_req_path', 'http_req_body', 'http_resp_status',
+                     'remote_addr', 'remote_port',
+                     'http_resp_message', 'http_resp_body']].head(100)
+
+
+def let_helper(start_time: str, service: px.Service):
+    ''' Compute the initial part of the let for requests.
+
+    Args:
+    @start_time: The timestamp of data to start at.
+    @service: The service to filter on.
+
+    '''
+    df = px.DataFrame(table='http_events', start_time=start_time)
+    df.service = df.ctx['service']
+    df = df[px.contains(df.service, service)]
+    df.pod = df.ctx['pod']
+    df.latency = df.http_resp_latency_ns
+
+    df.timestamp = px.bin(df.time_, window_ns)
+
+    df.resp_size = px.Bytes(px.length(df.http_resp_body))
+    df.failure = df.http_resp_status >= 400
+    filter_out_conds = ((df.http_req_path != '/health' or not filter_health_checks) and (
+        df.http_req_path != '/readyz' or not filter_ready_checks)) and (
+        df['remote_addr'] != '-' or not filter_unresolved_inbound)
+
+    df = df[filter_out_conds]
+    return df

--- a/pxl_scripts/pxbeta/service_endpoint/vis.json
+++ b/pxl_scripts/pxbeta/service_endpoint/vis.json
@@ -1,0 +1,179 @@
+{
+  "variables": [
+    {
+      "name": "start_time",
+      "type": "PX_STRING",
+      "description": "The relative start time of the window. Current time is assumed to be now",
+      "defaultValue": "-5m"
+    },
+    {
+      "name": "service",
+      "type": "PX_SERVICE",
+      "description": "The name of the service to get stats for. Format: ns/svc_name",
+      "defaultValue": ""
+    },
+    {
+      "name": "endpoint",
+      "type": "PX_STRING",
+      "description": "The endpoint to look at stats for. Format: /path/to/endpoint/*/more/path ",
+      "defaultValue": "/"
+    }
+  ],
+  "globalFuncs": [
+    {
+      "outputName": "endpoint_let_timeseries",
+      "func": {
+        "name": "endpoint_let_timeseries",
+        "args": [
+          {
+            "name": "start_time",
+            "variable": "start_time"
+          },
+          {
+            "name": "service",
+            "variable": "service"
+          },
+          {
+            "name": "endpoint",
+            "variable": "endpoint"
+          }
+        ]
+      }
+    }
+  ],
+  "widgets": [
+    {
+      "name": "HTTP Requests",
+      "position": {
+        "x": 0,
+        "y": 0,
+        "w": 4,
+        "h": 3
+      },
+      "globalFuncOutputName": "endpoint_let_timeseries",
+      "displaySpec": {
+        "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
+        "timeseries": [
+          {
+            "value": "request_throughput",
+            "mode": "MODE_LINE"
+          }
+        ],
+        "title": "",
+        "yAxis": {
+          "label": "request throughput"
+        },
+        "xAxis": null
+      }
+    },
+    {
+      "name": "HTTP Errors",
+      "position": {
+        "x": 4,
+        "y": 0,
+        "w": 4,
+        "h": 3
+      },
+      "globalFuncOutputName": "endpoint_let_timeseries",
+      "displaySpec": {
+        "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
+        "timeseries": [
+          {
+            "value": "errors_per_ns",
+            "mode": "MODE_LINE"
+          }
+        ],
+        "title": "",
+        "yAxis": {
+          "label": "error rate"
+        },
+        "xAxis": null
+      }
+    },
+    {
+      "name": "HTTP Latency",
+      "position": {
+        "x": 8,
+        "y": 0,
+        "w": 4,
+        "h": 3
+      },
+      "globalFuncOutputName": "endpoint_let_timeseries",
+      "displaySpec": {
+        "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
+        "timeseries": [
+          {
+            "value": "latency_p50",
+            "mode": "MODE_LINE"
+          },
+          {
+            "value": "latency_p90",
+            "mode": "MODE_LINE"
+          },
+          {
+            "value": "latency_p99",
+            "mode": "MODE_LINE"
+          }
+        ],
+        "title": "",
+        "yAxis": {
+          "label": "Latency"
+        },
+        "xAxis": null
+      }
+    },
+    {
+      "name": "HTTP Response Data Throughput",
+      "position": {
+        "x": 0,
+        "y": 3,
+        "w": 4,
+        "h": 3
+      },
+      "globalFuncOutputName": "endpoint_let_timeseries",
+      "displaySpec": {
+        "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
+        "timeseries": [
+          {
+            "value": "bytes_per_ns",
+            "mode": "MODE_LINE"
+          }
+        ],
+        "title": "",
+        "yAxis": {
+          "label": "Response data throughput"
+        },
+        "xAxis": null
+      }
+    },
+    {
+      "name": "Sample of Slow Requests",
+      "position": {
+        "x": 4,
+        "y": 6,
+        "w": 8,
+        "h": 3
+      },
+      "func": {
+        "name": "endpoint_slow_requests",
+        "args": [
+          {
+            "name": "start_time",
+            "variable": "start_time"
+          },
+          {
+            "name": "service",
+            "variable": "service"
+          },
+          {
+            "name": "endpoint",
+            "variable": "endpoint"
+          }
+        ]
+      },
+      "displaySpec": {
+        "@type": "pixielabs.ai/pl.vispb.Table"
+      }
+    }
+  ]
+}

--- a/pxl_scripts/pxbeta/service_endpoints/manifest.yaml
+++ b/pxl_scripts/pxbeta/service_endpoints/manifest.yaml
@@ -1,0 +1,4 @@
+---
+short: Endpoints Overview
+long: >
+  This script gets an overview of the endpoints for a service, summarizing their request statistics.

--- a/pxl_scripts/pxbeta/service_endpoints/service_endpoints.pxl
+++ b/pxl_scripts/pxbeta/service_endpoints/service_endpoints.pxl
@@ -1,0 +1,117 @@
+# Copyright (c) Pixie Labs, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License")
+
+''' Endpoints Overview
+
+ This script gets an overview of all the endpoints in `service`.
+'''
+
+import px
+
+ns_per_ms = 1000 * 1000
+ns_per_s = 1000 * ns_per_ms
+# Window size to use on time_ column for bucketing.
+window_ns = px.DurationNanos(10 * ns_per_s)
+# Flag to filter out requests that come from an unresolvable IP.
+filter_unresolved_inbound = False
+# Flag to filter out health checks from the data.
+filter_health_checks = False
+# Flag to filter out ready checks from the data.
+filter_ready_checks = False
+
+
+def endpoints(start_time: str, service: px.Service):
+    ''' Get a list of the endpoints in `service`.
+
+    Args:
+    @start_time: The timestamp of data to start at.
+    @service: The service to filter on.
+
+    '''
+    df = endpoint_let_helper(start_time, service)
+    df = request_path_endpoint_clustering(df)
+    df = df.groupby(['endpoint']).agg()
+    df.endpoint = px.script_reference(df.endpoint, 'pxbeta/service_endpoint', {
+        'start_time': start_time,
+        'service': service,
+        'endpoint': df.endpoint,
+    })
+    return df
+
+def endpoint_let(start_time: str, service: px.Service):
+    ''' Compute the let as a timeseries for requests received by endpoints in `service`.
+
+    Args:
+    @start_time: The timestamp of data to start at.
+    @service: The service to filter on.
+
+    '''
+
+    # Calculate LET for each svc edge in the svc graph over each time window.
+    # Each edge starts at a requester ('remote_addr') and ends at a
+    # responder service.
+
+    df = endpoint_let_helper(start_time, service)
+    df = request_path_endpoint_clustering(df)
+
+    df = df.groupby(['timestamp', 'endpoint']).agg(
+        latency_quantiles=('latency', px.quantiles),
+        error_rate=('failure', px.mean),
+        throughput_total=('latency', px.count),
+        inbound_bytes_total=('req_size', px.sum),
+        outbound_bytes_total=('resp_size', px.sum)
+    )
+
+    df.latency_p50 = px.DurationNanos(px.floor(px.pluck_float64(df.latency_quantiles, 'p50')))
+    df.latency_p90 = px.DurationNanos(px.floor(px.pluck_float64(df.latency_quantiles, 'p90')))
+    df.latency_p99 = px.DurationNanos(px.floor(px.pluck_float64(df.latency_quantiles, 'p99')))
+
+    df.request_throughput = df.throughput_total / window_ns
+    df.inbound_throughput = df.inbound_bytes_total / window_ns
+    df.outbound_throughput = df.outbound_bytes_total / window_ns
+    df.error_rate = px.Percent(df.error_rate)
+    df.time_ = df.timestamp
+
+    return df[['time_', 'endpoint', 'latency_p50', 'latency_p90',
+               'latency_p99', 'request_throughput', 'error_rate',
+               'inbound_throughput', 'outbound_throughput']]
+
+
+def endpoint_let_helper(start_time: str, service: px.Service):
+    ''' Compute the let as a timeseries for requests received or by services in `namespace`.
+
+    Args:
+    @start_time: The timestamp of data to start at.
+    @namespace: The namespace to filter on.
+    @groupby_cols: The columns to group on.
+
+    '''
+    df = px.DataFrame(table='http_events', start_time=start_time)
+    df.service = df.ctx['service']
+    df = df[px.contains(df.service, service)]
+    df.latency = df.http_resp_latency_ns
+    df.timestamp = px.bin(df.time_, window_ns)
+
+    df.req_size = px.Bytes(px.length(df.http_req_body))
+    df.resp_size = px.Bytes(px.length(df.http_resp_body))
+    df.failure = df.http_resp_status >= 400
+    filter_out_conds = ((df.http_req_path != '/health' or not filter_health_checks) and (
+        df.http_req_path != '/readyz' or not filter_ready_checks)) and (
+        df['remote_addr'] != '-' or not filter_unresolved_inbound)
+
+    df = df[filter_out_conds]
+    return df
+
+
+def request_path_endpoint_clustering(let_df):
+    clustering_df = let_df.agg(
+        clustering=("http_req_path", px._build_request_path_clusters)
+    )
+    merged_df = let_df.merge(
+        clustering_df, how="outer", right_on=[], left_on=[], suffixes=["", ""]
+    )
+    merged_df.endpoint = px._predict_request_path_cluster(
+        merged_df.http_req_path, merged_df.clustering
+    )
+    merged_df.drop(["clustering"])
+    return merged_df

--- a/pxl_scripts/pxbeta/service_endpoints/vis.json
+++ b/pxl_scripts/pxbeta/service_endpoints/vis.json
@@ -1,0 +1,191 @@
+{
+  "variables": [
+    {
+      "name": "start_time",
+      "type": "PX_STRING",
+      "description": "The relative start time of the window. Current time is assumed to be now",
+      "defaultValue": "-5m"
+    },
+    {
+      "name": "service",
+      "type": "PX_SERVICE",
+      "description": "The name of the service to get stats for.",
+      "defaultValue": "default"
+    }
+  ],
+  "globalFuncs": [
+    {
+      "outputName": "endpoint_let",
+      "func": {
+        "name": "endpoint_let",
+        "args": [
+          {
+            "name": "start_time",
+            "variable": "start_time"
+          },
+          {
+            "name": "service",
+            "variable": "service"
+          }
+        ]
+      }
+    }
+  ],
+  "widgets": [
+    {
+      "name": "Endpoints",
+      "position": {
+        "x": 0,
+        "y": 0,
+        "w": 4,
+        "h": 3
+      },
+      "func": {
+        "name": "endpoints",
+        "args": [
+          {
+            "name": "start_time",
+            "variable": "start_time"
+          },
+          {
+            "name": "service",
+            "variable": "service"
+          }
+        ]
+      },
+      "displaySpec": {
+        "@type": "pixielabs.ai/pl.vispb.Table"
+      }
+    },
+    {
+      "name": "HTTP Request Throughput",
+      "position": {
+        "x": 4,
+        "y": 0,
+        "w": 4,
+        "h": 3
+      },
+      "globalFuncOutputName": "endpoint_let",
+      "displaySpec": {
+        "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
+        "timeseries": [
+          {
+            "value": "request_throughput",
+            "mode": "MODE_LINE",
+            "series": "endpoint",
+            "stackBySeries": false
+          }
+        ],
+        "title": "",
+        "yAxis": {
+          "label": "requests per second"
+        },
+        "xAxis": null
+      }
+    },
+    {
+      "name": "HTTP Request Error Rate",
+      "position": {
+        "x": 8,
+        "y": 0,
+        "w": 4,
+        "h": 3
+      },
+      "globalFuncOutputName": "endpoint_let",
+      "displaySpec": {
+        "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
+        "timeseries": [
+          {
+            "value": "error_rate",
+            "mode": "MODE_LINE",
+            "series": "endpoint",
+            "stackBySeries": false
+          }
+        ],
+        "title": "",
+        "yAxis": {
+          "label": "error rate (%)"
+        },
+        "xAxis": null
+      }
+    },
+    {
+      "name": "HTTP P50 Latency",
+      "position": {
+        "x": 0,
+        "y": 3,
+        "w": 4,
+        "h": 3
+      },
+      "globalFuncOutputName": "endpoint_let",
+      "displaySpec": {
+        "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
+        "timeseries": [
+          {
+            "value": "latency_p50",
+            "mode": "MODE_LINE",
+            "series": "endpoint",
+            "stackBySeries": false
+          }
+        ],
+        "title": "",
+        "yAxis": {
+          "label": "Mean latency"
+        },
+        "xAxis": null
+      }
+    },
+    {
+      "name": "HTTP P90 Latency",
+      "position": {
+        "x": 4,
+        "y": 3,
+        "w": 4,
+        "h": 3
+      },
+      "globalFuncOutputName": "endpoint_let",
+      "displaySpec": {
+        "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
+        "timeseries": [
+          {
+            "value": "latency_p90",
+            "mode": "MODE_LINE",
+            "series": "endpoint",
+            "stackBySeries": false
+          }
+        ],
+        "title": "",
+        "yAxis": {
+          "label": "Mean latency"
+        },
+        "xAxis": null
+      }
+    },
+    {
+      "name": "HTTP P99 Latency",
+      "position": {
+        "x": 8,
+        "y": 3,
+        "w": 4,
+        "h": 3
+      },
+      "globalFuncOutputName": "endpoint_let",
+      "displaySpec": {
+        "@type": "pixielabs.ai/pl.vispb.TimeseriesChart",
+        "timeseries": [
+          {
+            "value": "latency_p99",
+            "mode": "MODE_LINE",
+            "series": "endpoint",
+            "stackBySeries": false
+          }
+        ],
+        "title": "",
+        "yAxis": {
+          "label": "Mean latency"
+        },
+        "xAxis": null
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds a directory for beta scripts called `pxbeta`.

Adds a beta script to list all the endpoints and their stats for a particular service:
![endpoints](https://user-images.githubusercontent.com/10334089/109903550-c50b1d80-7c50-11eb-99b4-09ea94c680ca.png)
Adds a beta script to show stats for a specific endpoint:
![endpoint](https://user-images.githubusercontent.com/10334089/109903609-d522fd00-7c50-11eb-8e42-8868be6a0db4.png)
Note that this can't be merged until D7559 is released.