### PR TITLE
Fix capitalization of StackTraceFlameGraph

### DIFF
--- a/pxl_scripts/px/node/vis.json
+++ b/pxl_scripts/px/node/vis.json
@@ -292,7 +292,7 @@
         ]
       },
       "displaySpec": {
-        "@type": "pixielabs.ai/pl.vispb.StacktraceFlameGraph",
+        "@type": "pixielabs.ai/pl.vispb.StackTraceFlameGraph",
         "stacktraceColumn": "stack_trace",
         "countColumn": "count",
         "percentageColumn": "percent",

--- a/pxl_scripts/px/perf_flamegraph/vis.json
+++ b/pxl_scripts/px/perf_flamegraph/vis.json
@@ -72,7 +72,7 @@
         ]
       },
       "displaySpec": {
-        "@type": "pixielabs.ai/pl.vispb.StacktraceFlameGraph",
+        "@type": "pixielabs.ai/pl.vispb.StackTraceFlameGraph",
         "stacktraceColumn": "stack_trace",
         "countColumn": "count",
         "percentageColumn": "percent",

--- a/pxl_scripts/px/pod/vis.json
+++ b/pxl_scripts/px/pod/vis.json
@@ -438,7 +438,7 @@
         ]
       },
       "displaySpec": {
-        "@type": "pixielabs.ai/pl.vispb.StacktraceFlameGraph",
+        "@type": "pixielabs.ai/pl.vispb.StackTraceFlameGraph",
         "stacktraceColumn": "stack_trace",
         "countColumn": "count",
         "percentageColumn": "percent",


### PR DESCRIPTION
The correct capitalization in our protos is specified as StackTraceFlameGraph, so the visspecs should refer to it accordingly.