### PR TITLE
Update AugmentedTokenValidDuration to 90 min

### DIFF
--- a/src/cloud/auth/controllers/login.go
+++ b/src/cloud/auth/controllers/login.go
@@ -44,7 +44,7 @@ const (
 	// RefreshTokenValidDuration is duration that the refresh token is valid from current time.
 	RefreshTokenValidDuration = 90 * 24 * time.Hour
 	// AugmentedTokenValidDuration is the duration that the augmented token is valid from the current time.
-	AugmentedTokenValidDuration = 30 * time.Minute
+	AugmentedTokenValidDuration = 90 * time.Minute
 	// SupportAccountDomain is the domain name of the Pixie support account which can access the org provided at login.
 	SupportAccountDomain = "pixie.support"
 )


### PR DESCRIPTION
Session timeouts related to the augmented token present a less than ideal UXP flow. To mitigate the need to constantly grab a refresh token on long lived use of Pixie, we can up the duration of the token to 90 minutes.